### PR TITLE
fix(metassr-html): prevent panic in HtmlPropsBuilder when scripts or styles are not set

### DIFF
--- a/crates/metassr-html/src/html_props.rs
+++ b/crates/metassr-html/src/html_props.rs
@@ -1,9 +1,6 @@
-use std::{
-    marker::Sized,
-    path::{Path, PathBuf},
-};
+use std::path::{Path, PathBuf};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct HtmlProps {
     // TODO: getting html language from a config file stored in web application root.
     pub lang: String,
@@ -65,15 +62,15 @@ impl HtmlPropsBuilder {
             body: self.body.as_ref().unwrap_or(&String::new()).to_owned(),
             scripts: self
                 .scripts
-                .as_ref()
-                .unwrap()
+                .as_deref()
+                .unwrap_or(&[])
                 .iter()
                 .map(|p| Path::new(p).to_path_buf())
                 .collect(),
             styles: self
                 .styles
-                .as_ref()
-                .unwrap()
+                .as_deref()
+                .unwrap_or(&[])
                 .iter()
                 .map(|p| Path::new(p).to_path_buf())
                 .collect(),


### PR DESCRIPTION
## Problem

`HtmlPropsBuilder::build()` called `.unwrap()` directly on `self.scripts` and
`self.styles`, both of which are `Option<Vec<String>>`. If a caller builds
`HtmlProps` without setting scripts or styles, this panics at runtime - even
though omitting them is a perfectly valid use case (e.g. a page with no
stylesheets or no client-side JS).

## Changes

- **Fix panic:** replaced `.as_ref().unwrap()` with `.as_deref().unwrap_or(&[])`
  on both `scripts` and `styles` in `HtmlPropsBuilder::build()`, so an unset
  field safely produces an empty `Vec` instead of panicking.
- **Remove unused import:** dropped `use std::marker::Sized` which was not needed.
- **Derive `Default`:** added `#[derive(Default)]` to `HtmlProps` since all its
  fields (`String`, `Vec<PathBuf>`) already implement `Default`.

## Before / After
```rust
// Before - panics if .scripts() or .styles() was never called
scripts: self.scripts.as_ref().unwrap().iter()...
styles:  self.styles.as_ref().unwrap().iter()...

// After - returns empty Vec safely
scripts: self.scripts.as_deref().unwrap_or(&[]).iter()...
styles:  self.styles.as_deref().unwrap_or(&[]).iter()...
```

## Testing

Call `HtmlPropsBuilder::new().build()` without setting scripts or styles -
previously panicked, now returns `HtmlProps` with empty `scripts` and `styles`.