### PR TITLE
fix(api-handler): index.js files now map to parent directory route

### DIFF
--- a/crates/metassr-api-handler/src/scanner.rs
+++ b/crates/metassr-api-handler/src/scanner.rs
@@ -24,17 +24,23 @@ pub fn scan_api_dir(api_dir: &Path) -> Vec<ApiRouteFile> {
     scan_api_dir_recursive(api_dir, api_dir, &mut routes);
 
     // Deduplicate routes to prevent Axum from panicking on duplicate route registration.
-    let mut seen = std::collections::HashSet::new();
+    // Note: read_dir order is nondeterministic, so we sort first to ensure the winner
+    // is always deterministic (shorter path wins; index.js naturally loses to a sibling
+    // flat file because its path component count is greater).
+    routes.sort_by(|a, b| a.file_path.cmp(&b.file_path));
+    let mut seen: std::collections::HashMap<String, std::path::PathBuf> =
+        std::collections::HashMap::new();
     routes.retain(|r| {
-        if seen.contains(&r.route_path) {
+        if let Some(kept) = seen.get(&r.route_path) {
             tracing::warn!(
-                "Duplicate API route '{}' from file {:?} — skipping.",
+                "Duplicate API route '{}': keeping {:?}, skipping {:?}.",
                 r.route_path,
+                kept,
                 r.file_path,
             );
             false
         } else {
-            seen.insert(r.route_path.clone());
+            seen.insert(r.route_path.clone(), r.file_path.clone());
             true
         }
     });
@@ -112,41 +118,41 @@ mod tests {
     use super::build_route_path;
     use std::path::Path;
 
+    /// Test case for a regular file mapping to a named route.
     #[test]
-    fn regular_file_maps_to_named_route() {
-        // api/hello.js -> /api/hello
+    fn test_regular_file_maps_to_named_route() {
         let relative = Path::new("hello.js");
         let full = Path::new("/project/src/api/hello.js");
         assert_eq!(build_route_path(relative, full), "/api/hello");
     }
 
+    /// Test case for an index.js at the api root mapping to /api.
     #[test]
-    fn index_file_at_root_maps_to_api_root() {
-        // api/index.js -> /api
+    fn test_index_file_at_root_maps_to_api_root() {
         let relative = Path::new("index.js");
         let full = Path::new("/project/src/api/index.js");
         assert_eq!(build_route_path(relative, full), "/api");
     }
 
+    /// Test case for a nested regular file mapping to its full path.
     #[test]
-    fn nested_regular_file_maps_to_full_path() {
-        // api/users/list.js -> /api/users/list
+    fn test_nested_regular_file_maps_to_full_path() {
         let relative = Path::new("users/list.js");
         let full = Path::new("/project/src/api/users/list.js");
         assert_eq!(build_route_path(relative, full), "/api/users/list");
     }
 
+    /// Test case for a nested index.js mapping to its parent directory route.
     #[test]
-    fn nested_index_file_maps_to_parent_directory_route() {
-        // api/users/index.js -> /api/users  (not /api/users/index)
+    fn test_nested_index_file_maps_to_parent_directory_route() {
         let relative = Path::new("users/index.js");
         let full = Path::new("/project/src/api/users/index.js");
         assert_eq!(build_route_path(relative, full), "/api/users");
     }
 
+    /// Test case for a deeply nested index.js mapping to its parent directory route.
     #[test]
-    fn deeply_nested_index_file_maps_to_parent_directory_route() {
-        // api/v1/users/index.js -> /api/v1/users
+    fn test_deeply_nested_index_file_maps_to_parent_directory_route() {
         let relative = Path::new("v1/users/index.js");
         let full = Path::new("/project/src/api/v1/users/index.js");
         assert_eq!(build_route_path(relative, full), "/api/v1/users");

--- a/crates/metassr-api-handler/src/scanner.rs
+++ b/crates/metassr-api-handler/src/scanner.rs
@@ -1,5 +1,6 @@
 //! Directory scanner for API route files.
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 /// Represents a discovered API route file.
@@ -25,11 +26,10 @@ pub fn scan_api_dir(api_dir: &Path) -> Vec<ApiRouteFile> {
 
     // Deduplicate routes to prevent Axum from panicking on duplicate route registration.
     // Note: read_dir order is nondeterministic, so we sort first to ensure the winner
-    // is always deterministic (shorter path wins; index.js naturally loses to a sibling
-    // flat file because its path component count is greater).
+    // is always deterministic. Lexicographic order puts `users/index.js` before `users.js`,
+    // so the index file is kept and the flat sibling is skipped.
     routes.sort_by(|a, b| a.file_path.cmp(&b.file_path));
-    let mut seen: std::collections::HashMap<String, std::path::PathBuf> =
-        std::collections::HashMap::new();
+    let mut seen: HashMap<String, PathBuf> = HashMap::new();
     routes.retain(|r| {
         if let Some(kept) = seen.get(&r.route_path) {
             tracing::warn!(

--- a/crates/metassr-api-handler/src/scanner.rs
+++ b/crates/metassr-api-handler/src/scanner.rs
@@ -63,17 +63,25 @@ fn scan_api_dir_recursive(base_path: &Path, current_path: &Path, routes: &mut Ve
 }
 
 /// Build the HTTP route path from the file path.
-/// Example: api/users/list.js -> /api/users/list
+///
+/// Files named `index.js` map to the route of their parent directory:
+/// - `api/users/index.js`  -> `/api/users`
+/// - `api/hello.js`        -> `/api/hello`
+/// - `api/users/list.js`   -> `/api/users/list`
 fn build_route_path(relative_path: &Path, full_path: &Path) -> String {
     let route_parts: Vec<&str> = relative_path.iter().filter_map(|s| s.to_str()).collect();
 
     let mut route_path = String::from("/api");
     for (i, part) in route_parts.iter().enumerate() {
         if i == route_parts.len() - 1 {
-            // Last part is the filename, remove extension
+            // Last part is the filename — remove extension.
+            // If the stem is "index", skip it so that e.g. `users/index.js`
+            // maps to `/api/users` rather than `/api/users/index`.
             if let Some(stem) = full_path.file_stem().and_then(|s| s.to_str()) {
-                route_path.push('/');
-                route_path.push_str(stem);
+                if stem != "index" {
+                    route_path.push('/');
+                    route_path.push_str(stem);
+                }
             }
         } else {
             // Directory name
@@ -83,4 +91,50 @@ fn build_route_path(relative_path: &Path, full_path: &Path) -> String {
     }
 
     route_path
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_route_path;
+    use std::path::Path;
+
+    #[test]
+    fn regular_file_maps_to_named_route() {
+        // api/hello.js -> /api/hello
+        let relative = Path::new("hello.js");
+        let full = Path::new("/project/src/api/hello.js");
+        assert_eq!(build_route_path(relative, full), "/api/hello");
+    }
+
+    #[test]
+    fn index_file_at_root_maps_to_api_root() {
+        // api/index.js -> /api
+        let relative = Path::new("index.js");
+        let full = Path::new("/project/src/api/index.js");
+        assert_eq!(build_route_path(relative, full), "/api");
+    }
+
+    #[test]
+    fn nested_regular_file_maps_to_full_path() {
+        // api/users/list.js -> /api/users/list
+        let relative = Path::new("users/list.js");
+        let full = Path::new("/project/src/api/users/list.js");
+        assert_eq!(build_route_path(relative, full), "/api/users/list");
+    }
+
+    #[test]
+    fn nested_index_file_maps_to_parent_directory_route() {
+        // api/users/index.js -> /api/users  (not /api/users/index)
+        let relative = Path::new("users/index.js");
+        let full = Path::new("/project/src/api/users/index.js");
+        assert_eq!(build_route_path(relative, full), "/api/users");
+    }
+
+    #[test]
+    fn deeply_nested_index_file_maps_to_parent_directory_route() {
+        // api/v1/users/index.js -> /api/v1/users
+        let relative = Path::new("v1/users/index.js");
+        let full = Path::new("/project/src/api/v1/users/index.js");
+        assert_eq!(build_route_path(relative, full), "/api/v1/users");
+    }
 }

--- a/crates/metassr-api-handler/src/scanner.rs
+++ b/crates/metassr-api-handler/src/scanner.rs
@@ -22,6 +22,23 @@ pub fn scan_api_dir(api_dir: &Path) -> Vec<ApiRouteFile> {
     }
 
     scan_api_dir_recursive(api_dir, api_dir, &mut routes);
+
+    // Deduplicate routes to prevent Axum from panicking on duplicate route registration.
+    let mut seen = std::collections::HashSet::new();
+    routes.retain(|r| {
+        if seen.contains(&r.route_path) {
+            tracing::warn!(
+                "Duplicate API route '{}' from file {:?} — skipping.",
+                r.route_path,
+                r.file_path,
+            );
+            false
+        } else {
+            seen.insert(r.route_path.clone());
+            true
+        }
+    });
+
     routes
 }
 
@@ -74,9 +91,7 @@ fn build_route_path(relative_path: &Path, full_path: &Path) -> String {
     let mut route_path = String::from("/api");
     for (i, part) in route_parts.iter().enumerate() {
         if i == route_parts.len() - 1 {
-            // Last part is the filename — remove extension.
-            // If the stem is "index", skip it so that e.g. `users/index.js`
-            // maps to `/api/users` rather than `/api/users/index`.
+            // Skip "index" stem so `users/index.js` maps to `/api/users`.
             if let Some(stem) = full_path.file_stem().and_then(|s| s.to_str()) {
                 if stem != "index" {
                     route_path.push('/');
@@ -84,7 +99,6 @@ fn build_route_path(relative_path: &Path, full_path: &Path) -> String {
                 }
             }
         } else {
-            // Directory name
             route_path.push('/');
             route_path.push_str(part);
         }


### PR DESCRIPTION
If you create `src/api/users/index.js`, it was being registered at
/api/users/index instead of /api/users.

The index.js convention (common in Next.js, Express, etc.) means the
file represents the route of its parent directory, not a route named
"index". Nobody expects to call /api/users/index.


# Solution 

Fixed by checking if the file stem is "index" and skipping it when
building the route path. Added 5 unit tests covering all cases.

Tested inside Docker with MetaCall (cargo test -p metassr-api-handler).