### PR TITLE
fix(metassr-watcher): replace eprintln! with tracing::error! for consistent logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,9 @@ members = [
 [workspace.package]
 version = "1.0.0-alpha"
 
+[workspace.dependencies]
+tracing = "0.1.40"
+
 [[bin]]
 name = "metassr"
 path = "metassr-cli/src/main.rs"

--- a/crates/metassr-watcher/Cargo.toml
+++ b/crates/metassr-watcher/Cargo.toml
@@ -9,3 +9,4 @@ serde_json = "1.0.122"
 notify = { version = "8.0.0", features = ["serde"] }
 notify-debouncer-full = "0.6.0"
 tokio = { version = "1.36.0", features = ["full"] }
+tracing.workspace = true

--- a/crates/metassr-watcher/src/lib.rs
+++ b/crates/metassr-watcher/src/lib.rs
@@ -4,6 +4,7 @@ use notify::RecursiveMode;
 use notify_debouncer_full::{self, DebounceEventResult, DebouncedEvent};
 use std::{path::Path, time::Duration};
 use tokio::sync::broadcast;
+use tracing::error;
 
 pub struct FileWatcher {
     watcher: notify_debouncer_full::Debouncer<
@@ -31,7 +32,7 @@ impl FileWatcher {
                 }
                 Err(errors) => {
                     for err in errors {
-                        eprintln!("Watch Error: {err}");
+                        error!("Watch error: {err}");
                     }
                 }
             },


### PR DESCRIPTION
## Problem

`FileWatcher` uses `eprintln!` to report watch errors, while the rest of the codebase uses `tracing` for all logging:
```rust
eprintln!("Watch Error: {err}");
```

This means file watcher errors bypass the structured logging system entirely - they won't appear in log files, won't respect log level filtering, and are inconsistent with every other crate in the project.

## Changes

**`crates/metassr-watcher/src/lib.rs`**
- `eprintln!("Watch Error: {err}")` → `error!("Watch error: {err}")`
- Added `use tracing::error`

**`crates/metassr-watcher/Cargo.toml`**
- Added `tracing = "0.1.40"` dependency (matches version used across workspace)

## Note

Could not verify output locally due to the MetaCall native dependency requirement. The change is a mechanical replacement verified against the existing `tracing` usage pattern throughout the codebase.