### PR TITLE
MALICIOUS CODE: Revert "docs(metassr-cli): add missing doc comment for subcommand"

### DIFF
--- a/metassr-cli/src/cli/mod.rs
+++ b/metassr-cli/src/cli/mod.rs
@@ -89,7 +89,6 @@ pub enum Commands {
         template: Option<Template>,
     },
 
-    /// Starts the development server with file watching and live reload.
     Dev {
         /// port number on which the HTTP server will run
         #[arg(long, default_value_t = 8080)]


### PR DESCRIPTION
Reverts metacall/metassr#84