### PR TITLE
refactor(metassr-html): idiomatic From impls, simplified Display, and modernized builder bounds

### DIFF
--- a/crates/metassr-html/src/builder.rs
+++ b/crates/metassr-html/src/builder.rs
@@ -1,6 +1,6 @@
 use super::{html_props::HtmlProps, template::HtmlTemplate};
 use anyhow::Result;
-use std::{fmt::Display, fs::File, io::Write, path::PathBuf};
+use std::{fmt, fs::File, io::Write, path::PathBuf};
 
 const LANG_TAG: &str = "%LANG%";
 const HEAD_TAG: &str = "%HEAD%";
@@ -8,14 +8,32 @@ const BODY_TAG: &str = "%BODY%";
 const SCRIPTS_TAG: &str = "%SCRIPTS%";
 const STYLES_TAG: &str = "%STYLES%";
 
+/// The rendered HTML output produced by [`HtmlBuilder`].
+///
+/// Implements [`fmt::Display`] so it can be written directly to any formatter
+/// (e.g. `format!("{output}")`, `println!("{output}")`) without a redundant
+/// intermediate allocation.  Use [`HtmlOutput::write`] to persist the output
+/// to disk.
+///
+/// # Example
+///
+/// ```no_run
+/// use metassr_html::{builder::{HtmlBuilder, HtmlOutput}, html_props::HtmlPropsBuilder, template::HtmlTemplate};
+///
+/// let props = HtmlPropsBuilder::new().lang("en").build();
+/// let output: HtmlOutput = HtmlBuilder::new(HtmlTemplate::default(), props).generate();
+///
+/// // Display — no extra allocation
+/// println!("{output}");
+///
+/// // Owned String — allocated on demand via the auto-provided to_string()
+/// let html: String = output.to_string();
+/// ```
 #[derive(Debug, Clone)]
 pub struct HtmlOutput(String);
 
 impl HtmlOutput {
-    pub fn from(html: &str) -> Self {
-        Self(html.to_string())
-    }
-
+    /// Write the rendered HTML to `path`, creating the file if it does not exist.
     pub fn write(&self, path: PathBuf) -> Result<()> {
         let mut file = File::create(path)?;
         file.write_all(self.0.as_bytes())?;
@@ -23,12 +41,34 @@ impl HtmlOutput {
     }
 }
 
-impl Display for HtmlOutput {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_fmt(format_args!("{}", self.0))
+/// Construct an [`HtmlOutput`] from an owned [`String`] without copying.
+impl From<String> for HtmlOutput {
+    fn from(html: String) -> Self {
+        Self(html)
     }
 }
 
+/// Construct an [`HtmlOutput`] from a string slice.
+///
+/// Prefer [`From<String>`] when you already own a `String` to avoid the
+/// extra allocation.
+impl From<&str> for HtmlOutput {
+    fn from(html: &str) -> Self {
+        Self(html.to_owned())
+    }
+}
+
+/// Display the rendered HTML.  Because `Display` is implemented directly,
+/// `to_string()` (provided automatically by the standard library) reuses this
+/// implementation — there is no separate, heap-duplicating `ToString` impl.
+impl fmt::Display for HtmlOutput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// Builds a complete HTML document by substituting template placeholders with
+/// the supplied [`HtmlProps`].
 pub struct HtmlBuilder {
     template: HtmlTemplate,
     props: HtmlProps,
@@ -39,6 +79,7 @@ impl HtmlBuilder {
         Self { template, props }
     }
 
+    /// Render the template and return an [`HtmlOutput`].
     pub fn generate(&self) -> HtmlOutput {
         let scripts = self
             .props
@@ -56,10 +97,10 @@ impl HtmlBuilder {
             .collect::<Vec<String>>()
             .join("");
 
+        // `format!("{}", self.template)` uses HtmlTemplate's Display impl to
+        // obtain an owned String; we then substitute placeholders in-place.
         HtmlOutput::from(
-            &self
-                .template
-                .to_string()
+            format!("{}", self.template)
                 .replace(LANG_TAG, &self.props.lang)
                 .replace(HEAD_TAG, &self.props.head)
                 .replace(BODY_TAG, &self.props.body)
@@ -73,7 +114,7 @@ impl HtmlBuilder {
 mod tests {
     use crate::{html_props::HtmlPropsBuilder, template::HtmlTemplate};
 
-    use super::HtmlBuilder;
+    use super::{HtmlBuilder, HtmlOutput};
 
     #[test]
     fn generating_html() {
@@ -143,5 +184,43 @@ mod tests {
         assert!(!html.contains("%BODY%"));
         assert!(!html.contains("%SCRIPTS%"));
         assert!(!html.contains("%STYLES%"));
+    }
+
+    // ── New tests for the refactored From / Display impls ──────────────
+
+    /// From<&str> and From<String> should produce identical output.
+    #[test]
+    fn html_output_from_str_and_from_string_are_equivalent() {
+        let raw = "<html><body>hello</body></html>";
+        let from_str = HtmlOutput::from(raw);
+        let from_string = HtmlOutput::from(raw.to_owned());
+        assert_eq!(from_str.to_string(), from_string.to_string());
+    }
+
+    /// Display must round-trip the inner string exactly — no extra whitespace,
+    /// no extra wrapping.
+    #[test]
+    fn html_output_display_roundtrips_content() {
+        let raw = "<html><body>round-trip test</body></html>";
+        let output = HtmlOutput::from(raw);
+        // format! uses Display, which must not clone or transform the inner string
+        assert_eq!(format!("{output}"), raw);
+    }
+
+    /// to_string() (auto-derived from Display) must equal a direct format! call.
+    /// This proves there is no separate ToString impl that could diverge.
+    #[test]
+    fn html_output_to_string_matches_display() {
+        let raw = "<!DOCTYPE html><html></html>";
+        let output = HtmlOutput::from(raw);
+        assert_eq!(output.to_string(), format!("{output}"));
+    }
+
+    /// Cloning an HtmlOutput must produce an independent copy with the same content.
+    #[test]
+    fn html_output_clone_is_independent() {
+        let original = HtmlOutput::from("original content");
+        let cloned = original.clone();
+        assert_eq!(original.to_string(), cloned.to_string());
     }
 }

--- a/crates/metassr-html/src/html_props.rs
+++ b/crates/metassr-html/src/html_props.rs
@@ -1,8 +1,10 @@
 use std::path::{Path, PathBuf};
 
+/// Properties used by [`HtmlBuilder`](crate::builder::HtmlBuilder) to
+/// populate the HTML template.
 #[derive(Debug, Clone, Default)]
 pub struct HtmlProps {
-    // TODO: getting html language from a config file stored in web application root.
+    // TODO: read the HTML language from a config file in the web-application root.
     pub lang: String,
     pub head: String,
     pub body: String,
@@ -10,12 +12,25 @@ pub struct HtmlProps {
     pub styles: Vec<PathBuf>,
 }
 
-// impl HtmlProps {
-//     pub fn new() -> HtmlPropsBuilder {
-//         HtmlPropsBuilder::new()
-//     }
-// }
-
+/// Builder for [`HtmlProps`].
+///
+/// All string setters accept anything that implements `Into<String>` — this
+/// includes both `&str` literals and owned `String` values without requiring
+/// an explicit `.to_string()` call at the call site.
+///
+/// # Example
+///
+/// ```
+/// use metassr_html::html_props::HtmlPropsBuilder;
+///
+/// let props = HtmlPropsBuilder::new()
+///     .lang("en")
+///     .head("<title>My App</title>")
+///     .body("<div id=\"root\"></div>")
+///     .scripts(vec!["main.js".to_owned()])
+///     .styles(vec!["style.css".to_owned()])
+///     .build();
+/// ```
 #[derive(Debug, Clone)]
 pub struct HtmlPropsBuilder {
     lang: Option<String>,
@@ -35,31 +50,42 @@ impl HtmlPropsBuilder {
             styles: None,
         }
     }
-    pub fn lang<S: ToString + ?Sized>(mut self, lang: &S) -> Self {
-        self.lang = Some(lang.to_string());
+
+    /// Set the `lang` attribute on the `<html>` element (e.g. `"en"`).
+    pub fn lang(mut self, lang: impl Into<String>) -> Self {
+        self.lang = Some(lang.into());
         self
     }
-    pub fn head<S: ToString + ?Sized>(mut self, head: &S) -> Self {
-        self.head = Some(head.to_string());
+
+    /// Set the contents of the `<head>` section.
+    pub fn head(mut self, head: impl Into<String>) -> Self {
+        self.head = Some(head.into());
         self
     }
-    pub fn body<S: ToString + ?Sized>(mut self, body: &S) -> Self {
-        self.body = Some(body.to_string());
+
+    /// Set the contents of the `<body>` section.
+    pub fn body(mut self, body: impl Into<String>) -> Self {
+        self.body = Some(body.into());
         self
     }
+
+    /// Set the list of JavaScript bundle paths to inject as `<script>` tags.
     pub fn scripts(mut self, scripts: Vec<String>) -> Self {
         self.scripts = Some(scripts);
         self
     }
+
+    /// Set the list of CSS paths to inject as `<link rel="stylesheet">` tags.
     pub fn styles(mut self, styles: Vec<String>) -> Self {
         self.styles = Some(styles);
         self
     }
+
     pub fn build(&self) -> HtmlProps {
         HtmlProps {
-            lang: self.lang.as_ref().unwrap_or(&String::new()).to_owned(),
-            head: self.head.as_ref().unwrap_or(&String::new()).to_owned(),
-            body: self.body.as_ref().unwrap_or(&String::new()).to_owned(),
+            lang: self.lang.clone().unwrap_or_default(),
+            head: self.head.clone().unwrap_or_default(),
+            body: self.body.clone().unwrap_or_default(),
             scripts: self
                 .scripts
                 .as_deref()
@@ -81,5 +107,55 @@ impl HtmlPropsBuilder {
 impl Default for HtmlPropsBuilder {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::HtmlPropsBuilder;
+
+    /// Builder defaults must produce empty strings and empty vecs — no panics.
+    #[test]
+    fn default_build_produces_empty_props() {
+        let props = HtmlPropsBuilder::new().build();
+        assert!(props.lang.is_empty());
+        assert!(props.head.is_empty());
+        assert!(props.body.is_empty());
+        assert!(props.scripts.is_empty());
+        assert!(props.styles.is_empty());
+    }
+
+    /// Builder setters must accept &str without an explicit .to_string() call.
+    #[test]
+    fn builder_accepts_str_slices() {
+        let props = HtmlPropsBuilder::new()
+            .lang("en")
+            .head("<title>test</title>")
+            .body("<div></div>")
+            .build();
+        assert_eq!(props.lang, "en");
+        assert_eq!(props.head, "<title>test</title>");
+        assert_eq!(props.body, "<div></div>");
+    }
+
+    /// Builder setters must also accept owned Strings.
+    #[test]
+    fn builder_accepts_owned_strings() {
+        let props = HtmlPropsBuilder::new()
+            .lang(String::from("fr"))
+            .head(String::from("<title>bonjour</title>"))
+            .build();
+        assert_eq!(props.lang, "fr");
+    }
+
+    /// Scripts and styles are converted to PathBufs correctly.
+    #[test]
+    fn builder_converts_script_and_style_paths() {
+        let props = HtmlPropsBuilder::new()
+            .scripts(vec!["dist/main.js".to_owned()])
+            .styles(vec!["dist/style.css".to_owned()])
+            .build();
+        assert_eq!(props.scripts.len(), 1);
+        assert_eq!(props.styles.len(), 1);
     }
 }


### PR DESCRIPTION
## Summary
Four idiomatic Rust improvements to `metassr-html`. No behaviour changes - all existing tests pass and 8 new tests added.

## Changes

- **`HtmlOutput`**: Replace custom `pub fn from(html: &str)` with `impl From<String>` + `impl From<&str>`. `From<String>` moves the value in zero-copy; the old method shadowed the trait without implementing it.
- **`Display`**: Simplify `f.write_fmt(format_args!(…))` → `write!(f, …)`.
- **`generate()`**: Fix double allocation - `From<String>` now takes the owned `format!("{}", self.template)` directly instead of borrowing a `.to_string()` intermediary.
- **`HtmlPropsBuilder`**: Change setter bounds from `&S: ToString + ?Sized` to `impl Into<String>`. Accepts `&str`, `String`, and `Cow<str>` at call sites without explicit conversion and moves owned Strings without cloning. Also replace `unwrap_or(&String::new()).to_owned()` with `unwrap_or_default()`.

## Checklist
- [x] No behaviour changes
- [x] All existing tests pass
- [x] 8 new unit tests added
- [x] `cargo clippy` clean
- [x] `cargo fmt` applied