### PR TITLE
fix(live-reload): fix typo causing stylesheet cache-busting to silently fail in dev mode

### DIFF
--- a/crates/metassr-server/src/scripts/live-reload.js
+++ b/crates/metassr-server/src/scripts/live-reload.js
@@ -4,7 +4,7 @@
  * and updates the page accordingly.
  */
 
-(function() {
+(function () {
     let isReconnecting = false;
     let ws
 
@@ -71,8 +71,10 @@
         const links = document.querySelectorAll('link[rel="stylesheet"]');
         links.forEach(link => {
             const href = link.href.split('?')[0];
-            link.href = `$[href]?t=${Date.now()}`;
-        })
+            // Append a cache-busting timestamp to the stylesheet URL
+            // This forces the browser to fetch the new CSS instead of using the stale cached version
+            link.href = `${href}?t=${Date.now()}`;
+        });
     };
     // Start the live reload connection
     connect();


### PR DESCRIPTION
## Summary
`reloadStylesheets()` in `live-reload.js` had a typo - `$[href]` instead of `${href}` - meaning the cache-bust timestamp was never appended and browsers always served stale CSS in dev mode. This was a completely silent failure with no error in the console.

## Changes
- `$[href]?t=${Date.now()}` → `${href}?t=${Date.now()}`
- Added a comment explaining why the timestamp is appended
- Fixed missing semicolon after the `forEach` closing paren

## How to verify
In dev mode, change any `.css` file - the browser should now reload the stylesheet without a full page refresh.

## Checklist
- [x] No behaviour changes beyond the bug fix
- [x] `cargo fmt` applied