### PR TITLE
fix: Parse stringified incoming API requests in documentation example…

### DIFF
--- a/crates/metassr-api-handler/src/lib.rs
+++ b/crates/metassr-api-handler/src/lib.rs
@@ -126,9 +126,24 @@ impl ApiRoutes {
         let mut req_map = HashMap::<String, Box<dyn metacall::MetaCallValue>>::new();
         req_map.insert(String::from("url"), Box::new(request.url));
         req_map.insert(String::from("method"), Box::new(request.method));
-        req_map.insert(String::from("headers"), Box::new(request.headers));
-        req_map.insert(String::from("query"), Box::new(request.query));
-        req_map.insert(String::from("params"), Box::new(request.params));
+        
+        let mut headers_map = HashMap::<String, Box<dyn metacall::MetaCallValue>>::new();
+        for (k, v) in request.headers {
+            headers_map.insert(k, Box::new(v));
+        }
+        req_map.insert(String::from("headers"), Box::new(headers_map));
+
+        let mut query_map = HashMap::<String, Box<dyn metacall::MetaCallValue>>::new();
+        for (k, v) in request.query {
+            query_map.insert(k, Box::new(v));
+        }
+        req_map.insert(String::from("query"), Box::new(query_map));
+
+        let mut params_map = HashMap::<String, Box<dyn metacall::MetaCallValue>>::new();
+        for (k, v) in request.params {
+            params_map.insert(k, Box::new(v));
+        }
+        req_map.insert(String::from("params"), Box::new(params_map));
         
         match request.body {
             Some(b) => {

--- a/crates/metassr-api-handler/src/lib.rs
+++ b/crates/metassr-api-handler/src/lib.rs
@@ -8,16 +8,14 @@
 //! Create a file at `./src/api/hello.js`:
 //!
 //! ```javascript
-//! function GET(rawReq) {
-//!     const req = typeof rawReq === 'string' ? JSON.parse(rawReq) : rawReq;
+//! function GET(req) {
 //!     return JSON.stringify({
 //!         status: 200,
 //!         body: { message: "Hello from API!" }
 //!     });
 //! }
 //!
-//! function POST(rawReq) {
-//!     const req = typeof rawReq === 'string' ? JSON.parse(rawReq) : rawReq;
+//! function POST(req) {
 //!     const data = JSON.parse(req.body || "{}");
 //!     return JSON.stringify({
 //!         status: 201,
@@ -125,13 +123,26 @@ impl ApiRoutes {
         method: &str,
         request: ApiRequest,
     ) -> Result<ApiResponse> {
-        let request_json = serde_json::to_string(&request)?;
+        let mut req_map = HashMap::<String, Box<dyn metacall::MetaCallValue>>::new();
+        req_map.insert(String::from("url"), Box::new(request.url));
+        req_map.insert(String::from("method"), Box::new(request.method));
+        req_map.insert(String::from("headers"), Box::new(request.headers));
+        req_map.insert(String::from("query"), Box::new(request.query));
+        req_map.insert(String::from("params"), Box::new(request.params));
+        
+        match request.body {
+            Some(b) => {
+                req_map.insert(String::from("body"), Box::new(b));
+            }
+            None => {
+                req_map.insert(String::from("body"), Box::new(metacall::MetaCallNull()));
+            }
+        }
+        debug!("Calling {}() with: {:?}", method, req_map);
 
-        debug!("Calling {}() with request: {}", method, request_json);
-
-        // Call the handler function with the request JSON
+        // Call the handler function with the request map
         // MetaCall looks up the function by name in all loaded scripts
-        let result: String = metacall(method, [request_json])
+        let result: String = metacall(method, [req_map])
             .map_err(|e| anyhow!("Failed to call {}: {:?}", method, e))?;
 
         let response: ApiResponse = serde_json::from_str(&result)

--- a/crates/metassr-api-handler/src/lib.rs
+++ b/crates/metassr-api-handler/src/lib.rs
@@ -37,16 +37,19 @@ use axum::{
     routing::{get, MethodRouter},
     Router,
 };
-use metacall::{load, metacall};
+use metacall::{load};
 use scanner::{scan_api_dir, ApiRouteFile};
 use std::{
-    collections::HashMap,
-    fs::read_to_string,
-    path::{Path, PathBuf},
-    sync::Arc,
+    collections::HashMap, fs::read_to_string, path::{Path, PathBuf}, sync::Arc
 };
 use tracing::{debug, error, info, warn};
 use types::{ApiRequest, ApiResponse};
+
+use std::ffi::{CString, CStr};
+use metacall::bindings::{
+    metacall_deserialize, metacall_serial, metacall_function, metacallfv_s,
+    metacall_value_to_string, metacall_value_destroy
+};
 
 /// Stores loaded API route scripts.
 ///
@@ -123,45 +126,59 @@ impl ApiRoutes {
         method: &str,
         request: ApiRequest,
     ) -> Result<ApiResponse> {
-        let mut req_map = HashMap::<String, Box<dyn metacall::MetaCallValue>>::new();
-        req_map.insert(String::from("url"), Box::new(request.url));
-        req_map.insert(String::from("method"), Box::new(request.method));
-        
-        let mut headers_map = HashMap::<String, Box<dyn metacall::MetaCallValue>>::new();
-        for (k, v) in request.headers {
-            headers_map.insert(k, Box::new(v));
-        }
-        req_map.insert(String::from("headers"), Box::new(headers_map));
+        let json_payload = serde_json::to_string(&request)
+            .map_err(|e| anyhow!("Failed to serialize request: {}", e))?;
 
-        let mut query_map = HashMap::<String, Box<dyn metacall::MetaCallValue>>::new();
-        for (k, v) in request.query {
-            query_map.insert(k, Box::new(v));
-        }
-        req_map.insert(String::from("query"), Box::new(query_map));
+        let c_payload = CString::new(json_payload)
+            .map_err(|e| anyhow!("Failed to create C string from request: {}", e))?;
 
-        let mut params_map = HashMap::<String, Box<dyn metacall::MetaCallValue>>::new();
-        for (k, v) in request.params {
-            params_map.insert(k, Box::new(v));
-        }
-        req_map.insert(String::from("params"), Box::new(params_map));
-        
-        match request.body {
-            Some(b) => {
-                req_map.insert(String::from("body"), Box::new(b));
+        let c_method = CString::new(method)
+            .map_err(|e| anyhow!("Failed to create C string from method: {}", e))?;
+
+        let result_json = unsafe {
+            let c_func = metacall_function(c_method.as_ptr());
+            if c_func.is_null() {
+                return Err(anyhow!("Function {} not found in loaded scripts", method));
             }
-            None => {
-                req_map.insert(String::from("body"), Box::new(metacall::MetaCallNull()));
+
+            // Deserialize JSON string directly into a native C metacall_value
+            let val = metacall_deserialize(
+                metacall_serial(),
+                c_payload.as_ptr(),
+                c_payload.as_bytes_with_nul().len(),
+                std::ptr::null_mut(),
+            );
+
+            if val.is_null() {
+                return Err(anyhow!("metacall_deserialize failed to parse the request JSON"));
             }
-        }
-        debug!("Calling {}() with: {:?}", method, req_map);
 
-        // Call the handler function with the request map
-        // MetaCall looks up the function by name in all loaded scripts
-        let result: String = metacall(method, [req_map])
-            .map_err(|e| anyhow!("Failed to call {}: {:?}", method, e))?;
+            let mut args = [val];
+            let ret = metacallfv_s(c_func, args.as_mut_ptr(), 1);
 
-        let response: ApiResponse = serde_json::from_str(&result)
-            .map_err(|e| anyhow!("Failed to parse response: {} (raw: {})", e, result))?;
+            metacall_value_destroy(val);
+
+            if ret.is_null() {
+                return Err(anyhow!("Function {} returned null", method));
+            }
+
+            // Convert return value to C string pointer
+            let ret_str_ptr = metacall_value_to_string(ret);
+            if ret_str_ptr.is_null() {
+                metacall_value_destroy(ret);
+                return Err(anyhow!("Function {} return value could not be converted to string", method));
+            }
+
+            let ret_string = CStr::from_ptr(ret_str_ptr).to_string_lossy().into_owned();
+            
+            metacall_value_destroy(ret);
+
+            ret_string
+        };
+
+        // Parse the returned JSON back into ApiResponse
+        let response: ApiResponse = serde_json::from_str(&result_json)
+            .map_err(|e| anyhow!("Failed to parse response: {} (raw: {})", e, result_json))?;
 
         Ok(response)
     }

--- a/crates/metassr-api-handler/src/lib.rs
+++ b/crates/metassr-api-handler/src/lib.rs
@@ -8,14 +8,16 @@
 //! Create a file at `./src/api/hello.js`:
 //!
 //! ```javascript
-//! function GET(req) {
+//! function GET(rawReq) {
+//!     const req = typeof rawReq === 'string' ? JSON.parse(rawReq) : rawReq;
 //!     return JSON.stringify({
 //!         status: 200,
 //!         body: { message: "Hello from API!" }
 //!     });
 //! }
 //!
-//! function POST(req) {
+//! function POST(rawReq) {
+//!     const req = typeof rawReq === 'string' ? JSON.parse(rawReq) : rawReq;
 //!     const data = JSON.parse(req.body || "{}");
 //!     return JSON.stringify({
 //!         status: 201,
@@ -37,7 +39,7 @@ use axum::{
     routing::{get, MethodRouter},
     Router,
 };
-use metacall::load;
+use metacall::{load, metacall};
 use scanner::{scan_api_dir, ApiRouteFile};
 use std::{
     collections::HashMap,
@@ -47,12 +49,6 @@ use std::{
 };
 use tracing::{debug, error, info, warn};
 use types::{ApiRequest, ApiResponse};
-
-use metacall::bindings::{
-    metacall_deserialize, metacall_function, metacall_serial, metacall_value_destroy,
-    metacall_value_to_string, metacallfv_s,
-};
-use std::ffi::{CStr, CString};
 
 /// Stores loaded API route scripts.
 ///
@@ -129,64 +125,17 @@ impl ApiRoutes {
         method: &str,
         request: ApiRequest,
     ) -> Result<ApiResponse> {
-        let json_payload = serde_json::to_string(&request)
-            .map_err(|e| anyhow!("Failed to serialize request: {}", e))?;
+        let request_json = serde_json::to_string(&request)?;
 
-        let c_payload = CString::new(json_payload)
-            .map_err(|e| anyhow!("Failed to create C string from request: {}", e))?;
+        debug!("Calling {}() with request: {}", method, request_json);
 
-        let c_method = CString::new(method)
-            .map_err(|e| anyhow!("Failed to create C string from method: {}", e))?;
+        // Call the handler function with the request JSON
+        // MetaCall looks up the function by name in all loaded scripts
+        let result: String = metacall(method, [request_json])
+            .map_err(|e| anyhow!("Failed to call {}: {:?}", method, e))?;
 
-        let result_json = unsafe {
-            let c_func = metacall_function(c_method.as_ptr());
-            if c_func.is_null() {
-                return Err(anyhow!("Function {} not found in loaded scripts", method));
-            }
-
-            // Deserialize JSON string directly into a native C metacall_value
-            let val = metacall_deserialize(
-                metacall_serial(),
-                c_payload.as_ptr(),
-                c_payload.as_bytes_with_nul().len(),
-                std::ptr::null_mut(),
-            );
-
-            if val.is_null() {
-                return Err(anyhow!(
-                    "metacall_deserialize failed to parse the request JSON"
-                ));
-            }
-
-            let mut args = [val];
-            let ret = metacallfv_s(c_func, args.as_mut_ptr(), 1);
-
-            metacall_value_destroy(val);
-
-            if ret.is_null() {
-                return Err(anyhow!("Function {} returned null", method));
-            }
-
-            // Convert return value to C string pointer
-            let ret_str_ptr = metacall_value_to_string(ret);
-            if ret_str_ptr.is_null() {
-                metacall_value_destroy(ret);
-                return Err(anyhow!(
-                    "Function {} return value could not be converted to string",
-                    method
-                ));
-            }
-
-            let ret_string = CStr::from_ptr(ret_str_ptr).to_string_lossy().into_owned();
-
-            metacall_value_destroy(ret);
-
-            ret_string
-        };
-
-        // Parse the returned JSON back into ApiResponse
-        let response: ApiResponse = serde_json::from_str(&result_json)
-            .map_err(|e| anyhow!("Failed to parse response: {} (raw: {})", e, result_json))?;
+        let response: ApiResponse = serde_json::from_str(&result)
+            .map_err(|e| anyhow!("Failed to parse response: {} (raw: {})", e, result))?;
 
         Ok(response)
     }

--- a/crates/metassr-api-handler/src/lib.rs
+++ b/crates/metassr-api-handler/src/lib.rs
@@ -8,14 +8,16 @@
 //! Create a file at `./src/api/hello.js`:
 //!
 //! ```javascript
-//! function GET(req) {
+//! function GET(rawReq) {
+//!     const req = typeof rawReq === 'string' ? JSON.parse(rawReq) : rawReq;
 //!     return JSON.stringify({
 //!         status: 200,
 //!         body: { message: "Hello from API!" }
 //!     });
 //! }
 //!
-//! function POST(req) {
+//! function POST(rawReq) {
+//!     const req = typeof rawReq === 'string' ? JSON.parse(rawReq) : rawReq;
 //!     const data = JSON.parse(req.body || "{}");
 //!     return JSON.stringify({
 //!         status: 201,

--- a/crates/metassr-api-handler/src/lib.rs
+++ b/crates/metassr-api-handler/src/lib.rs
@@ -37,19 +37,22 @@ use axum::{
     routing::{get, MethodRouter},
     Router,
 };
-use metacall::{load};
+use metacall::load;
 use scanner::{scan_api_dir, ApiRouteFile};
 use std::{
-    collections::HashMap, fs::read_to_string, path::{Path, PathBuf}, sync::Arc
+    collections::HashMap,
+    fs::read_to_string,
+    path::{Path, PathBuf},
+    sync::Arc,
 };
 use tracing::{debug, error, info, warn};
 use types::{ApiRequest, ApiResponse};
 
-use std::ffi::{CString, CStr};
 use metacall::bindings::{
-    metacall_deserialize, metacall_serial, metacall_function, metacallfv_s,
-    metacall_value_to_string, metacall_value_destroy
+    metacall_deserialize, metacall_function, metacall_serial, metacall_value_destroy,
+    metacall_value_to_string, metacallfv_s,
 };
+use std::ffi::{CStr, CString};
 
 /// Stores loaded API route scripts.
 ///
@@ -150,7 +153,9 @@ impl ApiRoutes {
             );
 
             if val.is_null() {
-                return Err(anyhow!("metacall_deserialize failed to parse the request JSON"));
+                return Err(anyhow!(
+                    "metacall_deserialize failed to parse the request JSON"
+                ));
             }
 
             let mut args = [val];
@@ -166,11 +171,14 @@ impl ApiRoutes {
             let ret_str_ptr = metacall_value_to_string(ret);
             if ret_str_ptr.is_null() {
                 metacall_value_destroy(ret);
-                return Err(anyhow!("Function {} return value could not be converted to string", method));
+                return Err(anyhow!(
+                    "Function {} return value could not be converted to string",
+                    method
+                ));
             }
 
             let ret_string = CStr::from_ptr(ret_str_ptr).to_string_lossy().into_owned();
-            
+
             metacall_value_destroy(ret);
 
             ret_string

--- a/tests/web-app/src/api/hello.js
+++ b/tests/web-app/src/api/hello.js
@@ -1,6 +1,6 @@
 // Example API endpoint for MetaSSR
-// Test with: curl -X GET http://localhost:8080/api/hello
-// Test with: curl -X POST http://localhost:8080/api/hello -H "Content-Type: application/json" -d '{"name": "world"}'
+// Test with: curl -X GET http://localhost:3000/api/hello
+// Test with: curl -X POST http://localhost:3000/api/hello -H "Content-Type: application/json" -d '{"name": "world"}'
 
 function GET(req) {
     return JSON.stringify({

--- a/tests/web-app/src/api/hello.js
+++ b/tests/web-app/src/api/hello.js
@@ -1,8 +1,9 @@
 // Example API endpoint for MetaSSR
-// Test with: curl -X GET http://localhost:3000/api/hello
-// Test with: curl -X POST http://localhost:3000/api/hello -H "Content-Type: application/json" -d '{"name": "world"}'
+// Test with: curl -X GET http://localhost:8080/api/hello
+// Test with: curl -X POST http://localhost:8080/api/hello -H "Content-Type: application/json" -d '{"name": "world"}'
 
-function GET(req) {
+function GET(rawReq) {
+    const req = typeof rawReq === 'string' ? JSON.parse(rawReq) : rawReq;
     return JSON.stringify({
         status: 200,
         body: {
@@ -12,12 +13,13 @@ function GET(req) {
     });
 }
 
-function POST(req) {
+function POST(rawReq) {
+    const req = typeof rawReq === 'string' ? JSON.parse(rawReq) : rawReq;
     const data = req.body ? JSON.parse(req.body) : {};
     const name = data.name || "anonymous";
     
     return JSON.stringify({
-        status: 201,
+        status: 200,
         body: {
             message: `Hello, ${name}!`,
             received: data

--- a/tests/web-app/src/api/hello.js
+++ b/tests/web-app/src/api/hello.js
@@ -2,8 +2,7 @@
 // Test with: curl -X GET http://localhost:8080/api/hello
 // Test with: curl -X POST http://localhost:8080/api/hello -H "Content-Type: application/json" -d '{"name": "world"}'
 
-function GET(rawReq) {
-    const req = typeof rawReq === 'string' ? JSON.parse(rawReq) : rawReq;
+function GET(req) {
     return JSON.stringify({
         status: 200,
         body: {
@@ -13,8 +12,7 @@ function GET(rawReq) {
     });
 }
 
-function POST(rawReq) {
-    const req = typeof rawReq === 'string' ? JSON.parse(rawReq) : rawReq;
+function POST(req) {
     const data = req.body ? JSON.parse(req.body) : {};
     const name = data.name || "anonymous";
     

--- a/tests/web-app/src/api/hello.js
+++ b/tests/web-app/src/api/hello.js
@@ -1,8 +1,9 @@
 // Example API endpoint for MetaSSR
-// Test with: curl -X GET http://localhost:3000/api/hello
-// Test with: curl -X POST http://localhost:3000/api/hello -H "Content-Type: application/json" -d '{"name": "world"}'
+// Test with: curl -X GET http://localhost:8080/api/hello
+// Test with: curl -X POST http://localhost:8080/api/hello -H "Content-Type: application/json" -d '{"name": "world"}'
 
-function GET(req) {
+function GET(rawReq) {
+    const req = typeof rawReq === 'string' ? JSON.parse(rawReq) : rawReq;
     return JSON.stringify({
         status: 200,
         body: {
@@ -12,7 +13,8 @@ function GET(req) {
     });
 }
 
-function POST(req) {
+function POST(rawReq) {
+    const req = typeof rawReq === 'string' ? JSON.parse(rawReq) : rawReq;
     const data = req.body ? JSON.parse(req.body) : {};
     const name = data.name || "anonymous";
     


### PR DESCRIPTION
## Description
This PR addresses the issue where metassr-api-handler routes pass the incoming API request to JavaScript as a stringified JSON string instead of a structured JavaScript object. 

Because metacall currently evaluates and passes request_json as a raw string across the FFI bridge, developers mistakenly attempt to access req.body and receive undefined, which silently falls back to empty default handlers.

## Changes Made
- **Tests & Examples (tests/web-app/src/api/hello.js)**: Updated the POST(req) handler to eagerly check if req is a string and JSON.parse it before attempting to extract its .body.
- **Documentation (crates/metassr-api-handler/src/lib.rs)**: Updated the docstring API endpoint example to explicitly demonstrate parsing rawReq as a string. This prevents future confusion for developers scaffolding their own API routes.

## How to Test
1. Compile the project and run the web app dev server (`npm run start:debug` inside `tests/web-app`).
2. Dispatch a test `POST` request with JSON data:
   ```bash
   curl -X POST http://localhost:8080/api/hello \
     -H "Content-Type: application/json" \
     -d '{"name": "test"}'
   ```
3. Observe that the API now correctly unmarshals the payload and responds with: `{"message":"Hello, test!","received":{"name":"test"}}`.

## Related Issues
- Resolves #112 