### PR TITLE
propagate bundling errors from reject callback to exec() result

### DIFF
--- a/crates/metassr-bundler/src/lib.rs
+++ b/crates/metassr-bundler/src/lib.rs
@@ -26,6 +26,7 @@ const BUNDLING_FUNC: &str = "web_bundling";
 struct CompilationWait {
     checker: Mutex<CheckerState>,
     cond: Condvar,
+    error: Mutex<Option<String>>,
 }
 
 impl Default for CompilationWait {
@@ -33,6 +34,7 @@ impl Default for CompilationWait {
         Self {
             checker: Mutex::new(CheckerState::default()),
             cond: Condvar::new(),
+            error: Mutex::new(None),
         }
     }
 }
@@ -129,9 +131,13 @@ impl<'a> WebBundler<'a> {
         fn reject(err: Box<dyn MetaCallValue>, _: Option<Box<dyn Any>>) -> Box<dyn MetaCallValue> {
             let compilation_wait = &*Arc::clone(&IS_COMPILATION_WAIT);
             let mut started = compilation_wait.checker.lock().unwrap();
+            let err_msg = format!("{err:?}");
 
-            // Log the bundling error and mark the process as completed
+            // Store the error message and mark the process as completed
             error!("Bundling rejected: {err:?}");
+            if let Ok(mut error_lock) = compilation_wait.error.lock() {
+                *error_lock = Some(err_msg);
+            }
             started.make_true();
             compilation_wait.cond.notify_one();
 
@@ -162,6 +168,14 @@ impl<'a> WebBundler<'a> {
 
         // Reset the checker state to false after the process completes
         started.make_false();
+
+        // Check if there was an error during bundling
+        if let Ok(error_lock) = compilation_wait.error.lock() {
+            if let Some(error_msg) = error_lock.as_ref() {
+                return Err(anyhow!("Bundling failed: {}", error_msg));
+            }
+        }
+
         Ok(())
     }
 }
@@ -204,5 +218,26 @@ mod tests {
 
         let bundler = WebBundler::new(&targets, "tests/dist");
         assert!(bundler.is_err());
+    }
+
+    #[test]
+    fn bundling_with_broken_syntax_fails() {
+        clean();
+        let _metacall = initialize().unwrap();
+        let targets = HashMap::from([("pages/broken".to_owned(), "./tests/broken.js".to_owned())]);
+
+        match WebBundler::new(&targets, "tests/dist") {
+            Ok(bundler) => {
+                // This should now fail because broken.js has invalid syntax
+                assert!(
+                    bundler.exec().is_err(),
+                    "Expected bundling to fail with broken syntax"
+                );
+            }
+            Err(err) => {
+                panic!("WebBundler::new() failed unexpectedly: {err:?}",)
+            }
+        }
+        clean();
     }
 }

--- a/crates/metassr-bundler/src/lib.rs
+++ b/crates/metassr-bundler/src/lib.rs
@@ -185,6 +185,15 @@ mod tests {
 
     use super::*;
     use metacall::initialize;
+    use std::sync::Once;
+
+    static INIT: Once = Once::new();
+
+    fn ensure_metacall_initialized() {
+        INIT.call_once(|| {
+            initialize().expect("Failed to initialize MetaCall");
+        });
+    }
 
     fn clean() {
         let dist = Path::new("tests/dist");
@@ -195,8 +204,8 @@ mod tests {
 
     #[test]
     fn bundling_works() {
+        ensure_metacall_initialized();
         clean();
-        let _metacall = initialize().unwrap();
         let targets = HashMap::from([("pages/home".to_owned(), "./tests/home.js".to_owned())]);
 
         match WebBundler::new(&targets, "tests/dist") {
@@ -222,8 +231,8 @@ mod tests {
 
     #[test]
     fn bundling_with_broken_syntax_fails() {
+        ensure_metacall_initialized();
         clean();
-        let _metacall = initialize().unwrap();
         let targets = HashMap::from([("pages/broken".to_owned(), "./tests/broken.js".to_owned())]);
 
         match WebBundler::new(&targets, "tests/dist") {

--- a/crates/metassr-bundler/tests/broken.js
+++ b/crates/metassr-bundler/tests/broken.js
@@ -1,0 +1,9 @@
+// This file contains invalid JavaScript syntax to test bundling failure
+export default function broken() {
+  const x = {
+    foo: "bar"
+    // Missing comma here intentionally
+    baz: "qux"
+  };
+  return x;
+}


### PR DESCRIPTION
fixes #120 
This pr improves error handling in the `WebBundler` by capturing and propagating bundling errors.

changes:

* Added an `error` field to the `CompilationWait` struct to store error messages encountered during bundling.
* Modified the `reject` function in `WebBundler` to store the error message when bundling fails, allowing later retrieval.
* Updated the execution flow to check for stored errors after bundling completes and return a descriptive error if one occurred.