### PR TITLE
chore: typos in MetaSSR strings and metassr-utils description

### DIFF
--- a/crates/metassr-build/src/server/manifest.rs
+++ b/crates/metassr-build/src/server/manifest.rs
@@ -137,7 +137,7 @@ impl ManifestGenerator {
             let page_entry = match self.dist.pages.get(route) {
                 Some(e) => e,
                 None => {
-                    return Err(anyhow!("manifest: No Entries founded for: {:#?}", route));
+                    return Err(anyhow!("manifest: No entries found for: {:#?}", route));
                 }
             };
             manifest.insert(route, id, page_entry, dunce::canonicalize(path)?);

--- a/crates/metassr-build/src/server/mod.rs
+++ b/crates/metassr-build/src/server/mod.rs
@@ -92,7 +92,7 @@ impl Build for ServerSideBuilder {
         manifest.write(&self.dist_path.clone())?;
 
         if let Err(e) = HeadRenderer::new(&manifest.global.head, cache_dir.clone()).render(true) {
-            return Err(anyhow!("Coludn't render head: {e}"));
+            return Err(anyhow!("Couldn't render head: {e}"));
         }
 
         if self.building_type == BuildingType::StaticSiteGeneration {

--- a/crates/metassr-build/src/server/pages_generator.rs
+++ b/crates/metassr-build/src/server/pages_generator.rs
@@ -65,7 +65,7 @@ impl PagesGenerator {
                 }
                 None => {
                     return Err(anyhow!(
-                    "ssg: No Entries founded for this page: route = {route:#?}, path = {path:#?}",
+                    "ssg: No entries found for this page: route = {route:#?}, path = {path:#?}",
                 ))
                 }
             }

--- a/crates/metassr-fs-analyzer/src/dist_dir.rs
+++ b/crates/metassr-fs-analyzer/src/dist_dir.rs
@@ -149,7 +149,7 @@ impl DistDir {
     {
         let path = PathBuf::from(path);
 
-        // Check if the path exists, and return an error if not foundd
+        // Check if the path exists, and return an error if not found
         if !path.exists() {
             return Err(anyhow!("Dist directory not found: {path:#?}"));
         }

--- a/crates/metassr-server/src/rebuilder.rs
+++ b/crates/metassr-server/src/rebuilder.rs
@@ -101,7 +101,7 @@ impl Rebuilder {
             path if path.starts_with("src/components") => RebuildType::Component,
             path if path.starts_with("src/styles") => RebuildType::Style,
             path if path.starts_with("static") => RebuildType::Static,
-            // entered rebuilding everything if we're not surue of entered rebuilding kind
+            // entered rebuilding everything if we're not sure of entered rebuilding kind
             _ => RebuildType::Layout,
         };
 

--- a/crates/metassr-utils/Cargo.toml
+++ b/crates/metassr-utils/Cargo.toml
@@ -2,7 +2,7 @@
 name = "metassr-utils"
 version.workspace = true
 edition = "2021"
-description = "Important utilites for MetaSSR"
+description = "Important utilities for MetaSSR"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]


### PR DESCRIPTION
Fix #124 

Small text-only fixes for typos in error messages, comments, and `metassr-utils`’s package description.

- [x] `metassr-build` — "Couldn't render head" (`server/mod.rs`)
- [x] `metassr-fs-analyzer` — comment: "not found" (`dist_dir.rs`)
- [x] `metassr-server` — comment: "not sure" (`rebuilder.rs`)
- [x] `metassr-utils` — description: "utilities" (`Cargo.toml`)
- [x] `metassr-build` — "No entries found for" (`manifest.rs`, `pages_generator.rs`)