### PR TITLE
fix: correct BuildingType mapping for SSR and SSG in builder.rs

### DIFF
--- a/metassr-cli/src/cli/builder.rs
+++ b/metassr-cli/src/cli/builder.rs
@@ -109,8 +109,8 @@ impl FromStr for BuildingType {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
-            "ssr" | "server-side rendering" => Ok(BuildingType::Ssg),
-            "ssg" | "static-site generation" => Ok(BuildingType::Ssr),
+            "ssr" | "server-side rendering" => Ok(BuildingType::Ssr),
+            "ssg" | "static-site generation" => Ok(BuildingType::Ssg),
             _ => Err("unsupported option.".to_string()),
         }
     }


### PR DESCRIPTION
Fixes #126 

### What was wrong
The `FromStr` impl had the return values swapped — `"ssr"` was returning `Ssg` and `"ssg"` was returning `Ssr`.
```rust
// Before
"ssr" | "server-side rendering" => Ok(BuildingType::Ssg),  // wrong
"ssg" | "static-site generation" => Ok(BuildingType::Ssr), // wrong
// After
"ssr" | "server-side rendering" => Ok(BuildingType::Ssr),  // fixed
"ssg" | "static-site generation" => Ok(BuildingType::Ssg), // fixed
```
### Files changed
| File | Change |
|------|--------|
| `metassr-cli/src/cli/builder.rs` | Swapped the two `Ok(...)` return values in `FromStr` match arms |
