### PR TITLE
Add unit tests for metassr-cli

### DIFF
--- a/metassr-cli/src/cli/builder.rs
+++ b/metassr-cli/src/cli/builder.rs
@@ -115,3 +115,27 @@ impl FromStr for BuildingType {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_building_type() {
+        assert_eq!("ssr".parse::<BuildingType>().unwrap(), BuildingType::Ssr);
+        assert_eq!("ssg".parse::<BuildingType>().unwrap(), BuildingType::Ssg);
+    }
+
+    #[test]
+    fn parse_unsupported_option_returns_err() {
+        assert!("csr".parse::<BuildingType>().is_err());
+    }
+
+    #[test]
+    fn convert_to_server_building_type() {
+        let ssr: server::BuildingType = BuildingType::Ssr.into();
+        let ssg: server::BuildingType = BuildingType::Ssg.into();
+        assert_eq!(ssr, server::BuildingType::ServerSideRendering);
+        assert_eq!(ssg, server::BuildingType::StaticSiteGeneration);
+    }
+}

--- a/metassr-cli/src/cli/builder.rs
+++ b/metassr-cli/src/cli/builder.rs
@@ -109,8 +109,8 @@ impl FromStr for BuildingType {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
-            "ssr" | "server-side rendering" => Ok(BuildingType::Ssg),
-            "ssg" | "static-site generation" => Ok(BuildingType::Ssr),
+            "ssr" | "server-side rendering" => Ok(BuildingType::Ssr),
+            "ssg" | "static-site generation" => Ok(BuildingType::Ssg),
             _ => Err("unsupported option.".to_string()),
         }
     }

--- a/metassr-cli/src/cli/creator.rs
+++ b/metassr-cli/src/cli/creator.rs
@@ -123,3 +123,20 @@ impl FromStr for Template {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_template() {
+        assert_eq!("js".parse::<Template>().unwrap(), Template::Javascript);
+        assert_eq!("ts".parse::<Template>().unwrap(), Template::Typescript);
+    }
+
+    #[test]
+    fn as_str_round_trips() {
+        assert_eq!(Template::Javascript.as_str(), "javascript");
+        assert_eq!(Template::Typescript.as_str(), "typescript");
+    }
+}

--- a/metassr-cli/src/cli/mod.rs
+++ b/metassr-cli/src/cli/mod.rs
@@ -114,7 +114,11 @@ mod tests {
     #[test]
     fn build_defaults() {
         let args = parse(&["build"]).unwrap();
-        if let Commands::Build { out_dir, build_type } = args.commands {
+        if let Commands::Build {
+            out_dir,
+            build_type,
+        } = args.commands
+        {
             assert_eq!(out_dir, "dist");
             assert_eq!(build_type, BuildingType::Ssr);
         } else {
@@ -147,10 +151,14 @@ mod tests {
     #[test]
     fn create_with_all_flags() {
         let args = parse(&[
-            "create", "my-app",
-            "--version", "2.0.0",
-            "--description", "test project",
-            "--template", "typescript",
+            "create",
+            "my-app",
+            "--version",
+            "2.0.0",
+            "--description",
+            "test project",
+            "--template",
+            "typescript",
         ])
         .unwrap();
 

--- a/metassr-cli/src/cli/mod.rs
+++ b/metassr-cli/src/cli/mod.rs
@@ -99,3 +99,85 @@ pub enum Commands {
         ws_port: u16,
     },
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    fn parse(args: &[&str]) -> Result<Args, clap::Error> {
+        let mut full = vec!["metassr"];
+        full.extend_from_slice(args);
+        Args::try_parse_from(full)
+    }
+
+    #[test]
+    fn build_defaults() {
+        let args = parse(&["build"]).unwrap();
+        if let Commands::Build { out_dir, build_type } = args.commands {
+            assert_eq!(out_dir, "dist");
+            assert_eq!(build_type, BuildingType::Ssr);
+        } else {
+            panic!("expected Build command");
+        }
+    }
+
+    #[test]
+    fn run_defaults() {
+        let args = parse(&["run"]).unwrap();
+        if let Commands::Run { port, serve } = args.commands {
+            assert_eq!(port, 8080);
+            assert!(!serve);
+        } else {
+            panic!("expected Run command");
+        }
+    }
+
+    #[test]
+    fn dev_defaults() {
+        let args = parse(&["dev"]).unwrap();
+        if let Commands::Dev { port, ws_port } = args.commands {
+            assert_eq!(port, 8080);
+            assert_eq!(ws_port, 3001);
+        } else {
+            panic!("expected Dev command");
+        }
+    }
+
+    #[test]
+    fn create_with_all_flags() {
+        let args = parse(&[
+            "create", "my-app",
+            "--version", "2.0.0",
+            "--description", "test project",
+            "--template", "typescript",
+        ])
+        .unwrap();
+
+        if let Commands::Create {
+            project_name,
+            version,
+            description,
+            template,
+        } = args.commands
+        {
+            assert_eq!(project_name, Some("my-app".into()));
+            assert_eq!(version, Some("2.0.0".into()));
+            assert_eq!(description, Some("test project".into()));
+            assert_eq!(template, Some(Template::Typescript));
+        } else {
+            panic!("expected Create command");
+        }
+    }
+
+    #[test]
+    fn debug_mode_flag() {
+        let args = parse(&["--debug-mode", "all", "build"]).unwrap();
+        assert_eq!(args.debug_mode, Some(DebugMode::All));
+    }
+
+    #[test]
+    fn unknown_subcommand_is_rejected() {
+        assert!(parse(&["deploy"]).is_err());
+    }
+}


### PR DESCRIPTION
Fix #148 

## What Changed

Added **11 unit tests** across three modules in `metassr-cli`:

| Module         | Tests | What's Covered |
|----------------|-------|----------------|
| `cli::builder` | 3     | `BuildingType` `FromStr` parsing, invalid input rejection, conversion to `server::BuildingType` |
| `cli::creator` | 2     | `Template` `FromStr` parsing, `as_str()` round-trip |
| `cli::mod`     | 6     | Clap defaults for `build`, `run`, `dev`; `create` with all flags; `--debug-mode` flag; unknown subcommand rejection |

---

## How to Verify

```bash
cargo test -p metassr-cli