### PR TITLE
Fixed --debug-mode to show logs

### DIFF
--- a/crates/metassr-server/src/layers/tracing.rs
+++ b/crates/metassr-server/src/layers/tracing.rs
@@ -41,7 +41,7 @@ impl LayerSetup for TracingLayer {
         .on_request(move |req: &Request<_>, _span: &Span| {
             if options.enable_http_logging {
                 debug!(
-                    target = "http",
+                    target: "http",
                     user_agent=?  req.headers().get("user-agent").unwrap_or(&HeaderValue::from_str("Unknown").unwrap()),
                     "request: {} {}",
                     req.method(),
@@ -52,7 +52,7 @@ impl LayerSetup for TracingLayer {
         .on_response(move |res: &Response<_>, latency: Duration, _span: &Span| {
             if options.enable_http_logging {
                 debug!(
-                    target = "http",
+                    target: "http",
                     "[{}]: generated in {:?}",
                     res.status(),
                     latency,

--- a/metassr-cli/src/cli/dev.rs
+++ b/metassr-cli/src/cli/dev.rs
@@ -47,7 +47,7 @@ impl Dev {
             rebuilder,
             root_path,
             rebuild_tx,
-            allow_http_debug
+            allow_http_debug,
         })
     }
 

--- a/metassr-cli/src/cli/dev.rs
+++ b/metassr-cli/src/cli/dev.rs
@@ -24,6 +24,7 @@ pub struct Dev {
     rebuilder: Arc<Rebuilder>,
     root_path: PathBuf,
     rebuild_tx: broadcast::Sender<RebuildType>,
+    allow_http_debug: bool,
 }
 
 impl Dev {
@@ -32,6 +33,7 @@ impl Dev {
         ws_port: u16,
         root_path: PathBuf,
         building_type: BuildingType,
+        allow_http_debug: bool,
     ) -> Result<Self> {
         let (rebuild_tx, _) = broadcast::channel(100); //channel for rebuild notifications
 
@@ -45,6 +47,7 @@ impl Dev {
             rebuilder,
             root_path,
             rebuild_tx,
+            allow_http_debug
         })
     }
 
@@ -118,7 +121,7 @@ impl Dev {
         let server_configs = ServerConfigs {
             port: self.port,
             ws_port: self.ws_port,
-            _enable_http_logging: true,
+            _enable_http_logging: self.allow_http_debug,
             root_path: self.root_path.clone(),
             running_type: RunningType::ServerSideRendering,
             mode: metassr_server::ServerMode::Development,

--- a/metassr-cli/src/main.rs
+++ b/metassr-cli/src/main.rs
@@ -119,18 +119,14 @@ mod tests {
 
     #[test]
     fn all_flag_sets_global_debug() {
-        assert_eq!(
-            build_filter_string(Some(DebugMode::All)),
-            "debug"
-        );
+        assert_eq!(build_filter_string(Some(DebugMode::All)), "debug");
     }
 
     #[test]
     fn rust_log_env_overrides_cli() {
         std::env::set_var("RUST_LOG", "debug");
-        let result = EnvFilter::try_from_default_env().unwrap_or_else( |_| 
-            EnvFilter::new(build_filter_string(Some(DebugMode::Http)))
-        );
+        let result = EnvFilter::try_from_default_env()
+            .unwrap_or_else(|_| EnvFilter::new(build_filter_string(Some(DebugMode::Http))));
         std::env::remove_var("RUST_LOG");
         // assert that RUST_LOG overrides the cli flag
         assert_eq!(format!("{result}"), "debug");

--- a/metassr-cli/src/main.rs
+++ b/metassr-cli/src/main.rs
@@ -85,6 +85,7 @@ async fn main() -> Result<()> {
                 ws_port,
                 current_dir()?,
                 metassr_build::server::BuildingType::ServerSideRendering,
+                allow_http_debug
             )?
             .exec()
             .await?;

--- a/metassr-cli/src/main.rs
+++ b/metassr-cli/src/main.rs
@@ -17,6 +17,15 @@ use tracing_subscriber::{
     prelude::__tracing_subscriber_SubscriberExt, util::SubscriberInitExt, EnvFilter,
 };
 
+pub fn build_filter_string(debug_mode: Option<DebugMode>) -> String {
+    let level = match debug_mode {
+        Some(DebugMode::All) => "debug",
+        Some(DebugMode::Http) => "http=debug,info",
+        _ => "info",
+    };
+    level.to_string()
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     let args = Args::parse();
@@ -25,11 +34,7 @@ async fn main() -> Result<()> {
         [Some(DebugMode::All), Some(DebugMode::Metacall)].contains(&args.debug_mode);
     let allow_http_debug = [Some(DebugMode::All), Some(DebugMode::Http)].contains(&args.debug_mode);
 
-    let tracing_level = match args.debug_mode {
-        Some(DebugMode::All) => "debug",
-        Some(DebugMode::Http) => "http=debug,info",
-        _ => "info",
-    };
+    let tracing_level = build_filter_string(args.debug_mode);
     let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
         EnvFilter::new(tracing_level).add_directive("notify=off".parse().unwrap())
     });

--- a/metassr-cli/src/main.rs
+++ b/metassr-cli/src/main.rs
@@ -25,8 +25,9 @@ async fn main() -> Result<()> {
         [Some(DebugMode::All), Some(DebugMode::Metacall)].contains(&args.debug_mode);
     let allow_http_debug = [Some(DebugMode::All), Some(DebugMode::Http)].contains(&args.debug_mode);
     if let Commands::Create { .. } = args.commands {
-       let filter = EnvFilter::try_from_default_env()
-    .unwrap_or_else(|_| EnvFilter::new("info").add_directive("notify=off".parse().unwrap()));
+        let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+            EnvFilter::new("info").add_directive("notify=off".parse().unwrap())
+        });
 
         tracing_subscriber::fmt()
             .with_env_filter(filter)
@@ -35,8 +36,9 @@ async fn main() -> Result<()> {
             .compact()
             .init();
     } else {
-        let filter = EnvFilter::try_from_default_env()
-    .unwrap_or_else(|_| EnvFilter::new("info").add_directive("notify=off".parse().unwrap()));
+        let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+            EnvFilter::new("info").add_directive("notify=off".parse().unwrap())
+        });
 
         tracing_subscriber::registry()
             .with(filter)

--- a/metassr-cli/src/main.rs
+++ b/metassr-cli/src/main.rs
@@ -25,7 +25,8 @@ async fn main() -> Result<()> {
         [Some(DebugMode::All), Some(DebugMode::Metacall)].contains(&args.debug_mode);
     let allow_http_debug = [Some(DebugMode::All), Some(DebugMode::Http)].contains(&args.debug_mode);
     if let Commands::Create { .. } = args.commands {
-        let filter = EnvFilter::new("info").add_directive("notify=off".parse().unwrap());
+       let filter = EnvFilter::try_from_default_env()
+    .unwrap_or_else(|_| EnvFilter::new("info").add_directive("notify=off".parse().unwrap()));
 
         tracing_subscriber::fmt()
             .with_env_filter(filter)
@@ -34,7 +35,8 @@ async fn main() -> Result<()> {
             .compact()
             .init();
     } else {
-        let filter = EnvFilter::new("info").add_directive("notify=off".parse().unwrap());
+        let filter = EnvFilter::try_from_default_env()
+    .unwrap_or_else(|_| EnvFilter::new("info").add_directive("notify=off".parse().unwrap()));
 
         tracing_subscriber::registry()
             .with(filter)

--- a/metassr-cli/src/main.rs
+++ b/metassr-cli/src/main.rs
@@ -36,7 +36,7 @@ async fn main() -> Result<()> {
 
     let tracing_level = build_filter_string(args.debug_mode);
     let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
-        EnvFilter::new(tracing_level).add_directive("notify=off".parse().unwrap())
+        EnvFilter::new(&tracing_level).add_directive("notify=off".parse().unwrap())
     });
     if let Commands::Create { .. } = args.commands {
         tracing_subscriber::fmt()

--- a/metassr-cli/src/main.rs
+++ b/metassr-cli/src/main.rs
@@ -24,11 +24,10 @@ async fn main() -> Result<()> {
     let allow_metacall_debug =
         [Some(DebugMode::All), Some(DebugMode::Metacall)].contains(&args.debug_mode);
     let allow_http_debug = [Some(DebugMode::All), Some(DebugMode::Http)].contains(&args.debug_mode);
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+        EnvFilter::new("info").add_directive("notify=off".parse().unwrap())
+    });
     if let Commands::Create { .. } = args.commands {
-        let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
-            EnvFilter::new("info").add_directive("notify=off".parse().unwrap())
-        });
-
         tracing_subscriber::fmt()
             .with_env_filter(filter)
             .with_target(false)
@@ -36,10 +35,6 @@ async fn main() -> Result<()> {
             .compact()
             .init();
     } else {
-        let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
-            EnvFilter::new("info").add_directive("notify=off".parse().unwrap())
-        });
-
         tracing_subscriber::registry()
             .with(filter)
             .with(LoggingLayer {

--- a/metassr-cli/src/main.rs
+++ b/metassr-cli/src/main.rs
@@ -24,11 +24,11 @@ async fn main() -> Result<()> {
     let allow_metacall_debug =
         [Some(DebugMode::All), Some(DebugMode::Metacall)].contains(&args.debug_mode);
     let allow_http_debug = [Some(DebugMode::All), Some(DebugMode::Http)].contains(&args.debug_mode);
-    
-    let tracing_level = match args.debug_mode{
+
+    let tracing_level = match args.debug_mode {
         Some(DebugMode::All) => "debug",
         Some(DebugMode::Http) => "http=debug,info",
-        _ => "info"
+        _ => "info",
     };
     let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
         EnvFilter::new(tracing_level).add_directive("notify=off".parse().unwrap())
@@ -85,7 +85,7 @@ async fn main() -> Result<()> {
                 ws_port,
                 current_dir()?,
                 metassr_build::server::BuildingType::ServerSideRendering,
-                allow_http_debug
+                allow_http_debug,
             )?
             .exec()
             .await?;

--- a/metassr-cli/src/main.rs
+++ b/metassr-cli/src/main.rs
@@ -24,8 +24,14 @@ async fn main() -> Result<()> {
     let allow_metacall_debug =
         [Some(DebugMode::All), Some(DebugMode::Metacall)].contains(&args.debug_mode);
     let allow_http_debug = [Some(DebugMode::All), Some(DebugMode::Http)].contains(&args.debug_mode);
+    
+    let tracing_level = match args.debug_mode{
+        Some(DebugMode::All) => "debug",
+        Some(DebugMode::Http) => "http=debug,info",
+        _ => "info"
+    };
     let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
-        EnvFilter::new("info").add_directive("notify=off".parse().unwrap())
+        EnvFilter::new(tracing_level).add_directive("notify=off".parse().unwrap())
     });
     if let Commands::Create { .. } = args.commands {
         tracing_subscriber::fmt()

--- a/metassr-cli/src/main.rs
+++ b/metassr-cli/src/main.rs
@@ -99,3 +99,40 @@ async fn main() -> Result<()> {
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_flags_defaults_to_info() {
+        assert_eq!(build_filter_string(None), "info");
+    }
+
+    #[test]
+    fn http_flag_sets_http_debug() {
+        assert_eq!(
+            build_filter_string(Some(DebugMode::Http)),
+            "http=debug,info"
+        );
+    }
+
+    #[test]
+    fn all_flag_sets_global_debug() {
+        assert_eq!(
+            build_filter_string(Some(DebugMode::All)),
+            "debug"
+        );
+    }
+
+    #[test]
+    fn rust_log_env_overrides_cli() {
+        std::env::set_var("RUST_LOG", "debug");
+        let result = EnvFilter::try_from_default_env().unwrap_or_else( |_| 
+            EnvFilter::new(build_filter_string(Some(DebugMode::Http)))
+        );
+        std::env::remove_var("RUST_LOG");
+        // assert that RUST_LOG overrides the cli flag
+        assert_eq!(format!("{result}"), "debug");
+    }
+}


### PR DESCRIPTION
Fixes #152

Root causes
1. Hardcoded info tracing level : https://github.com/metacall/metassr/blob/master/metassr-cli/src/main.rs#L28
2.  target = vs target: in tracing macros: https://github.com/metacall/metassr/blob/master/crates/metassr-server/src/layers/tracing.rs#L44
to set metadata we need to initalize debug!() with target: 

along with that made dev.rs accept http_bool_debug, currently that was only limited to runners

as per discord convo added support to take in RUST_LOG
