### PR TITLE
rebuilding selected pages instead of all [on hold ]

### DIFF
--- a/crates/metassr-build/src/client/mod.rs
+++ b/crates/metassr-build/src/client/mod.rs
@@ -226,4 +226,137 @@ mod tests {
             }
         }
     }
+
+    fn scaffold_project_with_pages(root: &Path, pages: Vec<(&str, &str)>) {
+        scaffold_project(root);
+
+        let pages_dir = root.join("src/pages");
+        for (name, content) in pages {
+            let page_path = if name.contains('/') {
+                let parts: Vec<_> = name.split('/').collect();
+                let subdir = pages_dir.join(parts[0]);
+                fs::create_dir_all(&subdir).unwrap();
+                subdir.join(parts[1])
+            } else {
+                pages_dir.join(name)
+            };
+            fs::write(&page_path, content).unwrap();
+        }
+    }
+
+    #[test]
+    fn build_all_pages_by_default() {
+        let tmp = TempDir::new().unwrap();
+        scaffold_project_with_pages(
+            tmp.path(),
+            vec![
+                (
+                    "index.tsx",
+                    "export default function Index() { return <h1>Home</h1> }",
+                ),
+                (
+                    "about.tsx",
+                    "export default function About() { return <p>About</p> }",
+                ),
+            ],
+        );
+
+        let builder = ClientBuilder::new(tmp.path(), "dist").unwrap();
+        let mut cache_dir =
+            CacheDir::new(&format!("{}/cache", builder.dist_path.display())).unwrap();
+        let src = SourceDir::new(&builder.src_path).analyze().unwrap();
+
+        let all_pages = src.pages();
+        let (special_entries::App(app_path), _) = src.specials().unwrap();
+
+        for (page, page_path) in all_pages.iter() {
+            let hydrator = Hydrator::new(&app_path, page_path, "root")
+                .generate()
+                .unwrap();
+            let page = setup_page_path(page, "js");
+            cache_dir
+                .insert(&format!("pages/{}", page.display()), hydrator.as_bytes())
+                .unwrap();
+        }
+
+        let entries = cache_dir.entries_in_scope();
+        assert_eq!(entries.len(), 2, "expected 2 cache entries for all pages");
+    }
+
+    #[test]
+    fn build_only_target_pages() {
+        let tmp = TempDir::new().unwrap();
+        scaffold_project_with_pages(
+            tmp.path(),
+            vec![
+                (
+                    "index.tsx",
+                    "export default function Index() { return <h1>Home</h1> }",
+                ),
+                (
+                    "about.tsx",
+                    "export default function About() { return <p>About</p> }",
+                ),
+            ],
+        );
+
+        let builder = ClientBuilder::new(tmp.path(), "dist")
+            .unwrap()
+            .with_target_pages(vec!["index.tsx".to_string()]);
+
+        let mut cache_dir =
+            CacheDir::new(&format!("{}/cache", builder.dist_path.display())).unwrap();
+        let src = SourceDir::new(&builder.src_path).analyze().unwrap();
+
+        let all_pages = src.pages();
+        let pages= filter_target_pages(&builder.target_pages, all_pages).unwrap();
+
+        let (special_entries::App(app_path), _) = src.specials().unwrap();
+
+        for (page, page_path) in pages.iter() {
+            let hydrator = Hydrator::new(&app_path, page_path, "root")
+                .generate()
+                .unwrap();
+            let page = setup_page_path(page, "js");
+            cache_dir
+                .insert(&format!("pages/{}", page.display()), hydrator.as_bytes())
+                .unwrap();
+        }
+
+        let entries = cache_dir.entries_in_scope();
+        assert_eq!(
+            entries.len(),
+            1,
+            "expected 1 cache entry for target page only"
+        );
+        assert!(entries.keys().any(|k| k.contains("index")));
+    }
+
+    #[test]
+    fn error_on_missing_target_page() {
+        let tmp = TempDir::new().unwrap();
+        scaffold_project_with_pages(
+            tmp.path(),
+            vec![(
+                "index.tsx",
+                "export default function Index() { return <h1>Home</h1> }",
+            )],
+        );
+
+        let builder = ClientBuilder::new(tmp.path(), "dist")
+            .unwrap()
+            .with_target_pages(vec!["nonexistent.tsx".to_string()]);
+
+        let src = SourceDir::new(&builder.src_path).analyze().unwrap();
+        let all_pages = src.pages();
+
+        let pages = filter_target_pages(&builder.target_pages, all_pages);
+
+        assert!(pages.is_err(), "expected error for missing target page");
+        let err_msg = pages.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("nonexistent.tsx"),
+            "error should mention the missing page"
+        );
+    }
 }

--- a/crates/metassr-build/src/client/mod.rs
+++ b/crates/metassr-build/src/client/mod.rs
@@ -1,5 +1,5 @@
 use crate::traits::{Build, Generate};
-use crate::utils::setup_page_path;
+use crate::utils::{filter_target_pages, setup_page_path};
 use anyhow::{anyhow, Result};
 use dunce;
 use hydrator::Hydrator;
@@ -23,6 +23,7 @@ pub mod hydrator;
 pub struct ClientBuilder {
     src_path: PathBuf,
     dist_path: PathBuf,
+    target_pages: Option<Vec<String>>,
 }
 
 impl ClientBuilder {
@@ -43,7 +44,13 @@ impl ClientBuilder {
         Ok(Self {
             src_path,
             dist_path,
+            target_pages: None,
         })
+    }
+
+    pub fn with_target_pages(mut self, pages: Vec<String>) -> Self {
+        self.target_pages = Some(pages);
+        self
     }
 }
 
@@ -53,7 +60,9 @@ impl Build for ClientBuilder {
         let mut cache_dir = CacheDir::new(&format!("{}/cache", self.dist_path.display()))?;
         let src = SourceDir::new(&self.src_path).analyze()?;
 
-        let pages = src.pages();
+        let all_pages = src.pages();
+        let pages = filter_target_pages(&self.target_pages, all_pages).unwrap();
+
         let (special_entries::App(app_path), _) = src.specials()?;
 
         for (page, page_path) in pages.iter() {

--- a/crates/metassr-build/src/client/mod.rs
+++ b/crates/metassr-build/src/client/mod.rs
@@ -309,7 +309,7 @@ mod tests {
         let src = SourceDir::new(&builder.src_path).analyze().unwrap();
 
         let all_pages = src.pages();
-        let pages= filter_target_pages(&builder.target_pages, all_pages).unwrap();
+        let pages = filter_target_pages(&builder.target_pages, all_pages).unwrap();
 
         let (special_entries::App(app_path), _) = src.specials().unwrap();
 

--- a/crates/metassr-build/src/server/mod.rs
+++ b/crates/metassr-build/src/server/mod.rs
@@ -113,3 +113,134 @@ impl Build for ServerSideBuilder {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn scaffold_project(root: &Path) {
+        let src = root.join("src");
+        let pages = src.join("pages");
+        fs::create_dir_all(&pages).unwrap();
+
+        fs::write(
+            src.join("_app.tsx"),
+            "export default function App({ Component }) { return <Component /> }",
+        )
+        .unwrap();
+        fs::write(
+            src.join("_head.tsx"),
+            "export default function Head() { return <title>Test</title> }",
+        )
+        .unwrap();
+        fs::write(
+            pages.join("index.tsx"),
+            "export default function Index() { return <h1>Home</h1> }",
+        )
+        .unwrap();
+    }
+
+    fn scaffold_project_with_pages(root: &Path, pages: Vec<(&str, &str)>) {
+        scaffold_project(root); // Creates base structure + default index.tsx
+
+        let pages_dir = root.join("src/pages");
+        for (name, content) in pages {
+            let page_path = if name.contains('/') {
+                let parts: Vec<_> = name.split('/').collect();
+                let subdir = pages_dir.join(parts[0]);
+                fs::create_dir_all(&subdir).unwrap();
+                subdir.join(parts[1])
+            } else {
+                pages_dir.join(name)
+            };
+            fs::write(&page_path, content).unwrap();
+        }
+    }
+
+    #[test]
+    fn build_all_pages_by_default() {
+        let tmp = TempDir::new().unwrap();
+        scaffold_project_with_pages(
+            tmp.path(),
+            vec![
+                (
+                    "index.tsx",
+                    "export default function Index() { return <h1>Home</h1> }",
+                ),
+                (
+                    "about.tsx",
+                    "export default function About() { return <p>About</p> }",
+                ),
+            ],
+        );
+
+        let builder =
+            ServerSideBuilder::new(tmp.path(), "dist", BuildingType::ServerSideRendering).unwrap();
+        let src = SourceDir::new(&builder.src_path).analyze().unwrap();
+        let all_pages = src.clone().pages;
+
+        let pages = filter_target_pages(&builder.target_pages, all_pages).unwrap();
+
+        assert_eq!(pages.len(), 2, "expected 2 pages when no target filter");
+    }
+
+    #[test]
+    fn build_only_target_pages() {
+        let tmp = TempDir::new().unwrap();
+        scaffold_project_with_pages(
+            tmp.path(),
+            vec![
+                (
+                    "index.tsx",
+                    "export default function Index() { return <h1>Home</h1> }",
+                ),
+                (
+                    "about.tsx",
+                    "export default function About() { return <p>About</p> }",
+                ),
+            ],
+        );
+
+        let builder = ServerSideBuilder::new(tmp.path(), "dist", BuildingType::ServerSideRendering)
+            .unwrap()
+            .with_target_pages(vec!["index.tsx".to_string()]);
+
+        let src = SourceDir::new(&builder.src_path).analyze().unwrap();
+        let all_pages = src.clone().pages;
+
+        let pages = filter_target_pages(&builder.target_pages, all_pages).unwrap();
+
+        assert_eq!(pages.len(), 1, "expected 1 page when filtered");
+        assert!(pages.contains_key("index.tsx"));
+    }
+
+    #[test]
+    fn error_on_missing_target_page() {
+        let tmp = TempDir::new().unwrap();
+        scaffold_project_with_pages(
+            tmp.path(),
+            vec![(
+                "index.tsx",
+                "export default function Index() { return <h1>Home</h1> }",
+            )],
+        );
+
+        let builder = ServerSideBuilder::new(tmp.path(), "dist", BuildingType::ServerSideRendering)
+            .unwrap()
+            .with_target_pages(vec!["nonexistent.tsx".to_string()]);
+
+        let src = SourceDir::new(&builder.src_path).analyze().unwrap();
+        let all_pages = src.clone().pages;
+
+        let result = filter_target_pages(&builder.target_pages, all_pages);
+
+        assert!(result.is_err(), "expected error for missing target page");
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("nonexistent.tsx"),
+            "error should mention the missing page"
+        );
+    }
+}

--- a/crates/metassr-build/src/server/mod.rs
+++ b/crates/metassr-build/src/server/mod.rs
@@ -6,7 +6,7 @@ mod render;
 mod render_exec;
 mod targets;
 
-use crate::traits::Build;
+use crate::{traits::Build, utils::filter_target_pages};
 use manifest::ManifestGenerator;
 
 use metassr_bundler::WebBundler;
@@ -39,6 +39,7 @@ pub struct ServerSideBuilder {
     src_path: PathBuf,
     dist_path: PathBuf,
     building_type: BuildingType,
+    target_pages: Option<Vec<String>>,
 }
 
 impl ServerSideBuilder {
@@ -60,7 +61,13 @@ impl ServerSideBuilder {
             src_path,
             dist_path,
             building_type,
+            target_pages: None,
         })
+    }
+
+    pub fn with_target_pages(mut self, pages: Vec<String>) -> Self {
+        self.target_pages = Some(pages);
+        self
     }
 }
 // TODO: refactoring build function
@@ -70,7 +77,8 @@ impl Build for ServerSideBuilder {
         let mut cache_dir = CacheDir::new(&format!("{}/cache", self.dist_path.display()))?;
 
         let src = SourceDir::new(&self.src_path).analyze()?;
-        let pages = src.clone().pages;
+        let all_pages = src.clone().pages;
+        let pages = filter_target_pages(&self.target_pages, all_pages).unwrap();
         let (special_entries::App(app), special_entries::Head(head)) = src.specials()?;
 
         let targets = match TargetsGenerator::new(app, pages, &mut cache_dir).generate() {

--- a/crates/metassr-build/src/utils.rs
+++ b/crates/metassr-build/src/utils.rs
@@ -1,4 +1,6 @@
+use anyhow::{anyhow, Result};
 use std::{
+    collections::HashMap,
     ffi::OsStr,
     path::{Path, PathBuf},
 };
@@ -11,5 +13,31 @@ pub fn setup_page_path(page: &str, ext: &str) -> PathBuf {
             .join(format!("index.{ext}")),
 
         path => path.to_path_buf().with_extension(ext),
+    }
+}
+
+pub fn filter_target_pages(
+    target_pages: &Option<Vec<String>>,
+    all_pages: HashMap<String, PathBuf>,
+) -> Result<HashMap<String, PathBuf>> {
+    match target_pages {
+        Some(targets) => {
+            let mut filtered = HashMap::new();
+            for target in targets {
+                match all_pages.get(target) {
+                    Some(path) => {
+                        filtered.insert(target.clone(), path.clone());
+                    }
+                    None => {
+                        return Err(anyhow!(
+                            "Target page '{}' not found in source directory",
+                            target
+                        ))
+                    }
+                }
+            }
+            Ok(filtered)
+        }
+        None => Ok(all_pages),
     }
 }

--- a/crates/metassr-server/src/rebuilder.rs
+++ b/crates/metassr-server/src/rebuilder.rs
@@ -194,9 +194,9 @@ impl Rebuilder {
 
     fn page_path_to_route(&self, page_path: &Path) -> Result<String> {
         let path_str = to_js_path(page_path);
-        
+
         // Strip "src/pages/" prefix
-        match path_str.split("src/pages/").nth(1){
+        match path_str.split("src/pages/").nth(1) {
             Some(route) => Ok(route.to_string()),
             None => Err(anyhow!(
                 "Path {:?} does not contain 'src/pages/' prefix",

--- a/crates/metassr-server/src/rebuilder.rs
+++ b/crates/metassr-server/src/rebuilder.rs
@@ -22,6 +22,8 @@ use std::time::Instant;
 use notify_debouncer_full::DebouncedEvent;
 
 use tracing::{debug, error, warn};
+
+use metassr_utils::js_path::to_js_path;
 struct RebuildGuard<'a> {
     flag: &'a AtomicBool,
 }
@@ -190,10 +192,25 @@ impl Rebuilder {
         Ok(())
     }
 
+    fn page_path_to_route(&self, page_path: &Path) -> Result<String> {
+        let path_str = to_js_path(page_path);
+        
+        // Strip "src/pages/" prefix
+        match path_str.split("src/pages/").nth(1){
+            Some(route) => Ok(route.to_string()),
+            None => Err(anyhow!(
+                "Path {:?} does not contain 'src/pages/' prefix",
+                page_path
+            )),
+        }
+    }
+
     fn rebuild_page(&self, path: PathBuf) -> Result<()> {
         debug!("Rebuilding page {:?}", path);
 
-        debug!("Rebuilding page Rel path: {:?} Rebuilding page ", path);
+        let route = self.page_path_to_route(&path)?;
+        let target_pages = vec![route];
+        debug!("Rebuilding page with route: {:?}", target_pages);
 
         // Build client-side bundle
         {
@@ -204,6 +221,7 @@ impl Rebuilder {
                     .to_str()
                     .ok_or_else(|| anyhow!("couldn't find out dir path"))?,
             )?
+            .with_target_pages(target_pages.clone())
             .build();
 
             if let Err(e) = client_builder {
@@ -231,7 +249,8 @@ impl Rebuilder {
                     .to_str()
                     .ok_or_else(|| anyhow!("Invalid output path"))?,
                 self.building_type,
-            )?;
+            )?
+            .with_target_pages(target_pages);
 
             if let Err(e) = server_builder.build() {
                 error!(


### PR DESCRIPTION
currrently whenver any page has any changes done by the user all pages are rebuilt. this PR fixes to only rebuild the files which were modified

https://github.com/user-attachments/assets/635af74c-5deb-4baf-a768-f898d47dac0e


