### PR TITLE
fix js template: running render functions `React is not defined`

### DIFF
--- a/crates/metassr-create/src/lib.rs
+++ b/crates/metassr-create/src/lib.rs
@@ -75,8 +75,10 @@ mod test {
     include!(concat!(env!("OUT_DIR"), "/templates.rs"));
     #[test]
     fn load_template() {
+        let templates = load_templates();
+
         dbg!(&from_utf8(
-            load_templates()
+            templates
                 .get("typescript")
                 .unwrap()
                 .get("src/_head.tsx")
@@ -85,6 +87,17 @@ mod test {
         .unwrap()
         .replace(tags::VERSION, "1.0.0")
         .replace(tags::NAME, "MetaSSR"));
+
+        for (template, config) in [
+            ("javascript", "jsconfig.json"),
+            ("typescript", "tsconfig.json"),
+        ] {
+            let config = from_utf8(templates.get(template).unwrap().get(config).unwrap()).unwrap();
+            assert!(
+                config.contains(r#""jsx": "react-jsx""#),
+                "{template} template must use React's automatic JSX runtime"
+            );
+        }
     }
     #[test]
     fn generate_templates() -> Result<()> {

--- a/crates/metassr-create/templates/javascript/jsconfig.json
+++ b/crates/metassr-create/templates/javascript/jsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig to read more about this file */
-    "jsx": "react",
+    "jsx": "react-jsx",
     /* Projects */
     // "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
     // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */

--- a/crates/metassr-create/templates/javascript/src/_app.jsx
+++ b/crates/metassr-create/templates/javascript/src/_app.jsx
@@ -1,5 +1,4 @@
-import React, { ReactNode } from 'react';
-import { renderToString } from 'react-dom/server';
+import React from 'react';
 import { PageLayout } from './layout/PageLayout';
 import "./styles/global.css";
 

--- a/crates/metassr-create/templates/javascript/src/_head.jsx
+++ b/crates/metassr-create/templates/javascript/src/_head.jsx
@@ -1,5 +1,4 @@
-import React, { useState, ReactNode } from 'react';
-import { renderToString } from 'react-dom/server';
+import React from 'react';
 
 export default function Head() {
     return (
@@ -10,5 +9,4 @@ export default function Head() {
         </>
     );
 }
-
 

--- a/crates/metassr-create/templates/javascript/src/components/link.jsx
+++ b/crates/metassr-create/templates/javascript/src/components/link.jsx
@@ -1,11 +1,9 @@
-import React, { AnchorHTMLAttributes, ReactNode } from 'react';
-
-
+import React from 'react';
 
 export function Link({ children, href, ...args }) {
-    return (
-        <a target="_blank" rel="noopener noreferrer" href={href} {...args}>
-            {children}
-        </a>
-    );
+  return (
+    <a target="_blank" rel="noopener noreferrer" href={href} {...args}>
+      {children}
+    </a>
+  );
 };

--- a/crates/metassr-create/templates/javascript/src/pages/index.jsx
+++ b/crates/metassr-create/templates/javascript/src/pages/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState, ReactNode } from 'react';
+import React, { useState } from 'react';
 import metacallLogo from "../../static/assets/metacall-logo.png"
 
 import { Link } from '../components/link';
@@ -47,6 +47,5 @@ export default function Index() {
 	)
 
 }
-
 
 

--- a/crates/metassr-create/templates/typescript/tsconfig.json
+++ b/crates/metassr-create/templates/typescript/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig to read more about this file */
-    "jsx": "react",
+    "jsx": "react-jsx",
     /* Projects */
     // "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
     // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */

--- a/tests/README.md
+++ b/tests/README.md
@@ -5,10 +5,27 @@ This directory contains tests for the MetaSSR bundler.
 ## Web App Test
 
 The `web-app` example tests the bundler with a React application including:
+
 - TypeScript/TSX files
 - CSS imports (should be embedded in the bundle)
 - Image assets (should be inlined as base64)
 - Multiple pages and components
+
+## Random Users App
+
+The `random-users-app` example tests a small React page backed by an API route:
+
+- `static/users.json` stores 50 static users
+- `src/api/users.js` randomizes on the backend and returns 10 users from `/api/users`
+- `src/pages/index.tsx` fetches the API when the page loads, so every browser refresh requests a new random set
+
+Run it locally:
+
+```bash
+cd tests/random-users-app
+npm install
+npm run dev
+```
 
 ### Expected Output
 
@@ -58,6 +75,7 @@ dist/
 ### Running Tests Locally
 
 1. Build the project:
+
 ```bash
 cd tests/web-app
 npm install
@@ -65,6 +83,7 @@ npm run build
 ```
 
 2. Run the test script from anywhere in the project:
+
 ```bash
 # Run from project root
 ./tests/test-bundle.sh
@@ -92,6 +111,7 @@ The GitHub Actions workflow (`.github/workflows/test.yml`) automatically runs th
 The test script is designed to be easily configurable. Key configuration sections:
 
 ### Expected Directories
+
 ```bash
 EXPECTED_DIRECTORIES=(
     "cache"
@@ -107,6 +127,7 @@ EXPECTED_DIRECTORIES=(
 ```
 
 ### Expected Files
+
 ```bash
 EXPECTED_FILES=(
     "manifest.json"
@@ -116,6 +137,7 @@ EXPECTED_FILES=(
 ```
 
 ### Expected Patterns
+
 ```bash
 EXPECTED_PATTERNS=(
     "cache/pages/*/index.js"
@@ -127,6 +149,7 @@ EXPECTED_PATTERNS=(
 ```
 
 ### CSS Embedding Check
+
 ```bash
 CSS_SEPARATE_FILES_PATTERNS=(
     "pages/*/index.js.css"


### PR DESCRIPTION
fixes #162 
## Changes
- fix js template: do not import types in jsx files
- use `"jsx": "react-jsx"` in jconfig.json

`"jsx": "react"` selects React’s classic JSX transform.

  It converts:
`<App Component={Page} />
into:
`React.createElement(App, { Component: Page })`

That generated code requires a variable named React in the same module. Some template files, including the generated render module, didn’t provide that binding after bundling, so MetaCall executed:
`React.createElement(...)`
and threw `React is not defined
`"jsx": "react-jsx"` selects the automatic JSX transform. It converts the same JSX into roughly:
```js
import { jsx } from "react/jsx-runtime";
jsx(App, { Component: Page });
```
The required function is imported automatically, so no global React variable is needed.

Esbuild was configured for automatic JSX, but it detected the project’s `jsconfig.json` and `"jsx": "react"` overrode that setting.