### PR TITLE
Example: add python pygreet API Route

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -113,8 +113,8 @@ jobs:
           kill $SERVER_PID 2>/dev/null || true
           pkill -f "metassr.*run" 2>/dev/null || true
 
-      - name: SSR server tests (non-macOS)
-        if: runner.os != 'macOS'
+      - name: SSR server tests (Linux)
+        if: runner.os == 'Linux'
         timeout-minutes: 5
         working-directory: ./tests/web-app
         shell: bash
@@ -129,8 +129,27 @@ jobs:
           kill $SERVER_PID 2>/dev/null || true
           pkill -f "metassr.*run" 2>/dev/null || true
 
-      - name: Force kill metassr processes (Windows)
+      - name: SSR server tests (Windows)
         if: runner.os == 'Windows'
+        timeout-minutes: 5
+        working-directory: ./tests/web-app
+        shell: bash
+        run: |
+          PYTHONHOME=$(cygpath -u "$LOCALAPPDATA\\MetaCall\\metacall\\runtimes\\python")
+          export PYTHONHOME
+          export PATH="$PYTHONHOME:$PYTHONHOME/Scripts:$PATH"
+          npm run start:debug &
+          SERVER_PID=$!
+          for i in $(seq 1 30); do
+            curl --silent --output /dev/null http://localhost:8080 2>/dev/null && break
+            sleep 1
+          done
+          bash tests/ssr.sh
+          kill $SERVER_PID 2>/dev/null || true
+          pkill -f "metassr.*run" 2>/dev/null || true
+
+      - name: Force kill metassr processes (Windows)
+        if: always() && runner.os == 'Windows'
         shell: pwsh
         run: |
           taskkill /F /IM metassr.exe /T 2>$null
@@ -173,12 +192,31 @@ jobs:
           kill $SERVER_PID 2>/dev/null || true
           pkill -f "metassr.*run" 2>/dev/null || true
 
-      - name: SSG server tests (non-macOS)
-        if: runner.os != 'macOS'
+      - name: SSG server tests (Linux)
+        if: runner.os == 'Linux'
         timeout-minutes: 5
         working-directory: ./tests/web-app
         shell: bash
         run: |
+          npm run start:debug:ssg &
+          SERVER_PID=$!
+          for i in $(seq 1 30); do
+            curl --silent --output /dev/null http://localhost:8080 2>/dev/null && break
+            sleep 1
+          done
+          bash tests/ssg.sh
+          kill $SERVER_PID 2>/dev/null || true
+          pkill -f "metassr.*run" 2>/dev/null || true
+
+      - name: SSG server tests (Windows)
+        if: runner.os == 'Windows'
+        timeout-minutes: 5
+        working-directory: ./tests/web-app
+        shell: bash
+        run: |
+          PYTHONHOME=$(cygpath -u "$LOCALAPPDATA\\MetaCall\\metacall\\runtimes\\python")
+          export PYTHONHOME
+          export PATH="$PYTHONHOME:$PYTHONHOME/Scripts:$PATH"
           npm run start:debug:ssg &
           SERVER_PID=$!
           for i in $(seq 1 30); do

--- a/tests/web-app/src/api/pygreet.py
+++ b/tests/web-app/src/api/pygreet.py
@@ -1,0 +1,27 @@
+# Example API endpoint for MetaSSR
+# Test with: curl -X GET http://localhost:3000/api/pygreet
+# Test with: curl -X POST http://localhost:3000/api/pygreet -H "Content-Type: application/json" -d '{"name": "world"}'
+
+import json
+from datetime import datetime, timezone
+
+def GET(_req):
+    return json.dumps({
+        "status": 200,
+        "body": {
+            "message": "Hello from MetaSSR API!",
+            "timestamp": datetime.now(timezone.utc).isoformat()
+        }
+    })
+
+def POST(req):
+    req_obj = json.loads(req) if isinstance(req, str) else req
+    data = json.loads(req_obj.get("body", "{}")) if isinstance(req_obj.get("body"), str) else req_obj.get("body", {})
+    name = data.get("name", "anonymous")
+    return json.dumps({
+        "status": 201,
+        "body": {
+            "message": f"Hello, {name}!",
+            "received": data
+        }
+    })


### PR DESCRIPTION
Creating an API handler in Python breaks the Windows CI. This PR aims to add the python example and fix this behavior for the Windows CI.