### PR TITLE
feat: add baseline comparison to benchmark CI

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -21,12 +21,13 @@ jobs:
   benchmark:
     name: Benchmark
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 45
 
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          path: head
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -50,20 +51,59 @@ jobs:
       - name: Install wrk
         run: sudo apt-get update && sudo apt-get install -y wrk
 
-      - name: Build MetaSSR
+      - name: Build metassr
         run: cargo build --release
+        working-directory: ./head
 
       - name: Install binary
-        run: sudo cp target/release/metassr /usr/local/bin/metassr
+        run: sudo cp ./head/target/release/metassr /usr/local/bin/metassr
 
       - name: Setup benchmark app
-        working-directory: ./benchmarks/apps/metassr-app
+        working-directory: ./head/benchmarks/apps/metassr-app
         run: |
           npm install
           npm run build
 
+      # --- Baseline run (pull_request_target only) ---
+      - name: Checkout base ref
+        if: github.event_name == 'pull_request_target'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base
+
+      - name: Build baseline metassr
+        if: github.event_name == 'pull_request_target'
+        run: cargo build --release
+        working-directory: ./base
+        env:
+          CARGO_TARGET_DIR: ${{ github.workspace }}/target
+
+      - name: Run baseline benchmarks
+        if: github.event_name == 'pull_request_target'
+        run: |
+          cp ${{ github.workspace }}/target/release/metassr /tmp/metassr-baseline
+          PATH="/tmp:$PATH" metassr-baseline run --port 8080 &
+          for i in $(seq 1 30); do
+            curl --silent --output /dev/null http://localhost:8080 2>/dev/null && break
+            sleep 1
+          done
+          python3 head/benchmarks/benchmark.py --skip-build --output ${{ github.workspace }}/.bench/baseline --port 8080
+          kill $(lsof -ti:8080) 2>/dev/null || true
+          sleep 2
+
+      # --- Current run (always) ---
+      - name: Build metassr (current)
+        run: cargo build --release
+        working-directory: ./head
+        env:
+          CARGO_TARGET_DIR: ${{ github.workspace }}/target
+
+      - name: Install binary (current)
+        run: sudo cp ${{ github.workspace }}/target/release/metassr /usr/local/bin/metassr
+
       - name: Start server
-        working-directory: ./benchmarks/apps/metassr-app
+        working-directory: ./head/benchmarks/apps/metassr-app
         run: |
           npm start &
           for i in $(seq 1 30); do
@@ -71,11 +111,23 @@ jobs:
             sleep 1
           done
 
-      - name: Run benchmark
-        run: python3 benchmarks/benchmark.py --skip-build
+      - name: Run benchmarks
+        run: python3 head/benchmarks/benchmark.py --skip-build --output ${{ github.workspace }}/.bench/current --port 8080
 
       - name: Stop server
         run: kill $(lsof -ti:8080) 2>/dev/null || true
+
+      # --- Comparison ---
+      - name: Generate comparison report
+        if: github.event_name == 'pull_request_target'
+        run: python3 head/benchmarks/benchmark.py --compare ${{ github.workspace }}/.bench/baseline/results.json ${{ github.workspace }}/.bench/current/results.json --output ${{ github.workspace }}/.bench/
+
+      - name: Copy current summary for push events
+        if: github.event_name != 'pull_request_target'
+        run: cp ${{ github.workspace }}/.bench/current/summary.md ${{ github.workspace }}/.bench/summary.md
+
+      - name: Post summary to job page
+        run: cat ${{ github.workspace }}/.bench/summary.md >> $GITHUB_STEP_SUMMARY
 
       - name: Upload results
         if: always()

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 <p align='center'> SSR framework for React.js built on <a href="https://github.com/metacall/core">MetaCall</a> </p>
 </div>
 
-MetaSSR is a powerful Server-Side Rendering (SSR) framework crafted for high-performance, dynamic web applications. Built on Rust and leveraging the Axum web framework, MetaSSR integrates seamlessly with the Metacall Runtime, showcasing a real-world use case for polyglot programming. It was created as part of [Google Summer of Code 2024](https://summerofcode.withgoogle.com/archive/2024/projects/yRWw2gPh) by [Mohamed Emad](https://github.com/hulxv), to demonstrate the capabilities of polyglot programming.
+MetaSSR is a powerful Server-Side Rendering (SSR) framework crafted for high-performance, dynamic web applications. Built on Rust and Axum, MetaSSR uses Metacall Runtime, showcasing a real-world use case for polyglot programming. MetaSSR was created as part of [Google Summer of Code 2024](https://summerofcode.withgoogle.com/archive/2024/projects/yRWw2gPh) by [Mohamed Emad](https://github.com/hulxv), to demonstrate the capabilities of polyglot programming.
 
 ## Why MetaSSR?
 
@@ -59,17 +59,20 @@ docker run --rm -it metacall/metassr:dev bash
 ### Nix
 
 1. **Install Nix** (if not already installed):
+
    ```bash
    sh <(curl --proto '=https' --tlsv1.2 -L https://nixos.org/nix/install) --daemon
    ```
 
 2. **Enable Nix Flakes**:
+
    ```bash
    mkdir -p ~/.config/nix
    echo "experimental-features = nix-command flakes" >> ~/.config/nix/nix.conf
    ```
 
 3. **Enter Development Shell**:
+
    ```bash
    nix develop
    ```

--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -340,6 +340,163 @@ xychart-beta
     
     return summary
 
+def generate_comparison(baseline_file, current_file, output_dir):
+    """Generate comparison summary between two benchmark runs."""
+    baseline = json.loads(Path(baseline_file).read_text())
+    current = json.loads(Path(current_file).read_text())
+
+    base_index = {t["name"]: t for t in baseline["tests"]}
+    curr_index = {t["name"]: t for t in current["tests"]}
+
+    labels = ", ".join(f'"{s[0]}"' for s in SCENARIOS)
+
+    def collect(attr):
+        return [curr_index[s[0]][attr] for s in SCENARIOS]
+
+    def collect_base(attr):
+        return [base_index[s[0]][attr] for s in SCENARIOS]
+
+    base_rps_list = collect_base("rps")
+    curr_rps_list = collect("rps")
+    base_lat_list = collect_base("latency_ms")
+    curr_lat_list = collect("latency_ms")
+    base_p99_list = collect_base("p99_ms")
+    curr_p99_list = collect("p99_ms")
+    base_mem_list = collect_base("memory_mb")
+    curr_mem_list = collect("memory_mb")
+    base_req_list = collect_base("requests")
+    curr_req_list = collect("requests")
+
+    max_rps = max(max(base_rps_list), max(curr_rps_list)) * 1.2
+    max_lat = max(max(base_lat_list), max(curr_lat_list)) * 1.2
+    max_p99 = max(max(base_p99_list), max(curr_p99_list)) * 1.2
+    max_mem = max(max(base_mem_list), max(curr_mem_list)) * 1.2
+    max_req = max(max(base_req_list), max(curr_req_list)) * 1.2
+
+    base_rps_str = ", ".join(f"{int(v)}" for v in base_rps_list)
+    curr_rps_str = ", ".join(f"{int(v)}" for v in curr_rps_list)
+    base_lat_str = ", ".join(f"{v:.2f}" for v in base_lat_list)
+    curr_lat_str = ", ".join(f"{v:.2f}" for v in curr_lat_list)
+    base_p99_str = ", ".join(f"{v:.2f}" for v in base_p99_list)
+    curr_p99_str = ", ".join(f"{v:.2f}" for v in curr_p99_list)
+    base_mem_str = ", ".join(f"{v}" for v in base_mem_list)
+    curr_mem_str = ", ".join(f"{v}" for v in curr_mem_list)
+    base_req_str = ", ".join(f"{int(v)}" for v in base_req_list)
+    curr_req_str = ", ".join(f"{int(v)}" for v in curr_req_list)
+
+    def delta_str(old, new):
+        if old == 0:
+            return "N/A"
+        d = (new - old) / old * 100
+        return f"{d:+.2f}%"
+
+    def fmt_lat(ms):
+        if ms < 1:
+            return f"{ms*1000:.2f}us"
+        return f"{ms:.2f}ms"
+
+    table_rows = []
+    for name, _ in SCENARIOS:
+        b = base_index[name]
+        c = curr_index[name]
+        rps_d = delta_str(b["rps"], c["rps"])
+        lat_d = delta_str(b["latency_ms"], c["latency_ms"])
+        p99_d = delta_str(b["p99_ms"], c["p99_ms"])
+        mem_d = delta_str(b["memory_mb"], c["memory_mb"])
+        row = (
+            f"| {name} "
+            f"| {int(b['rps']):,} | {int(c['rps']):,} | {rps_d} "
+            f"| {fmt_lat(b['latency_ms'])} | {fmt_lat(c['latency_ms'])} | {lat_d} "
+            f"| {fmt_lat(b['p99_ms'])} | {fmt_lat(c['p99_ms'])} | {p99_d} "
+            f"| {b['memory_mb']:.1f}MB | {c['memory_mb']:.1f}MB | {mem_d} |"
+        )
+        table_rows.append(row)
+
+    avg_base_rps = sum(base_rps_list) / len(base_rps_list)
+    avg_curr_rps = sum(curr_rps_list) / len(curr_rps_list)
+    avg_base_lat = sum(base_lat_list) / len(base_lat_list)
+    avg_curr_lat = sum(curr_lat_list) / len(curr_lat_list)
+
+    summary = f"""# MetaSSR Benchmark Comparison
+
+**Date:** {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}
+
+## Performance Charts
+
+Legend: bars in order — **Baseline**, **Current**
+
+### Requests per Second
+```mermaid
+xychart-beta
+    title "Requests per Second"
+    x-axis [{labels}]
+    y-axis "RPS" 0 --> {max_rps:.0f}
+    bar [{base_rps_str}]
+    bar [{curr_rps_str}]
+```
+
+### Average Latency (ms)
+```mermaid
+xychart-beta
+    title "Average Latency"
+    x-axis [{labels}]
+    y-axis "Latency (ms)" 0 --> {max_lat:.2f}
+    bar [{base_lat_str}]
+    bar [{curr_lat_str}]
+```
+
+### P99 Latency (ms)
+```mermaid
+xychart-beta
+    title "P99 Latency"
+    x-axis [{labels}]
+    y-axis "P99 (ms)" 0 --> {max_p99:.2f}
+    bar [{base_p99_str}]
+    bar [{curr_p99_str}]
+```
+
+### Memory Usage (MB)
+```mermaid
+xychart-beta
+    title "Memory Usage"
+    x-axis [{labels}]
+    y-axis "Memory (MB)" 0 --> {max_mem:.0f}
+    bar [{base_mem_str}]
+    bar [{curr_mem_str}]
+```
+
+### Total Requests
+```mermaid
+xychart-beta
+    title "Total Requests Handled"
+    x-axis [{labels}]
+    y-axis "Requests" 0 --> {max_req:.0f}
+    bar [{base_req_str}]
+    bar [{curr_req_str}]
+```
+
+## Detailed Comparison
+
+| Test | Base RPS | PR RPS | RPS Δ | Base Latency | PR Latency | Lat Δ | Base P99 | PR P99 | P99 Δ | Base Mem | PR Mem | Mem Δ |
+|------|----------|--------|-------|-------------|-----------|-------|---------|-------|-------|----------|--------|-------|
+{chr(10).join(table_rows)}
+
+## Summary
+
+| Metric | Baseline | Current | Delta |
+|--------|----------|---------|-------|
+| Avg RPS | {avg_base_rps:,.0f} | {avg_curr_rps:,.0f} | {delta_str(avg_base_rps, avg_curr_rps)} |
+| Avg Latency | {fmt_lat(avg_base_lat)} | {fmt_lat(avg_curr_lat)} | {delta_str(avg_base_lat, avg_curr_lat)} |
+"""
+
+    out = Path(output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    (out / "summary.md").write_text(summary)
+    success(f"Comparison saved to {out / 'summary.md'}")
+    print(summary)
+    return summary
+
+
 def analyze_results(results):
     """Print analysis of benchmark results"""
     print(f"\n{'='*60}")
@@ -371,7 +528,19 @@ def main():
     parser.add_argument("-o", "--output", default=".bench", help="Output directory")
     parser.add_argument("-s", "--skip-build", action="store_true", help="Skip building")
     parser.add_argument("--analyze-only", metavar="FILE", help="Only analyze existing results.json")
+    parser.add_argument("--compare", nargs=2, metavar=("BASELINE", "CURRENT"),
+                        help="Compare two results.json files and generate comparison summary")
     args = parser.parse_args()
+    
+    # Handle compare mode
+    if args.compare:
+        baseline_file, current_file = args.compare
+        for f in [baseline_file, current_file]:
+            if not Path(f).exists():
+                error(f"File not found: {f}")
+                sys.exit(1)
+        generate_comparison(baseline_file, current_file, args.output)
+        return
     
     # Handle analyze-only mode
     if args.analyze_only:
@@ -388,7 +557,7 @@ def main():
     script_dir = Path(__file__).parent.resolve()
     project_root = script_dir.parent
     output_dir = project_root / args.output
-    output_dir.mkdir(exist_ok=True)
+    output_dir.mkdir(parents=True, exist_ok=True)
     
     print(f"{Colors.BLUE}=== MetaSSR Benchmark ==={Colors.NC}")
     


### PR DESCRIPTION
Run benchmarks on both base (master) and PR head, then generate a comparison report with side-by-side Mermaid charts and delta columns.

**benchmarks/benchmark.py:**
- Add `--compare` flag that takes two `results.json` files (baseline, current)
- Add `generate_comparison()` producing side-by-side charts for RPS, latency, P99, memory, total requests
- Add delta columns (percentage change) to the results table

**.github/workflows/bench.yml:**
- Checkout both base ref and PR head into separate directories
- Use shared `CARGO_TARGET_DIR` for incremental builds (second build reuses compiled dependencies)
- Run base benchmarks → `.bench/baseline/` (PR event only)
- Run head benchmarks → `.bench/current/` (always)
- Generate comparison report → `.bench/summary.md` (PR event only)
- Post summary to `GITHUB_STEP_SUMMARY` for inline rendering on the workflow run page
- Bump timeout to 45 minutes to accommodate double build/benchmark