### PR TITLE
Introduce new crate: metassr-config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1016,6 +1016,7 @@ dependencies = [
  "metacall-sys",
  "metassr-build",
  "metassr-bundler",
+ "metassr-config",
  "metassr-create",
  "metassr-server",
  "metassr-utils",
@@ -1031,6 +1032,7 @@ dependencies = [
 name = "metassr-config"
 version = "1.0.0-alpha"
 dependencies = [
+ "anyhow",
  "toml",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -426,6 +426,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -575,6 +581,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -688,6 +700,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown",
 ]
 
 [[package]]
@@ -909,6 +931,7 @@ dependencies = [
  "metacall-sys",
  "metassr-build",
  "metassr-bundler",
+ "metassr-config",
  "metassr-create",
  "metassr-fs-analyzer",
  "metassr-html",
@@ -1002,6 +1025,13 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "metassr-config"
+version = "1.0.0-alpha"
+dependencies = [
+ "toml",
 ]
 
 [[package]]
@@ -1468,6 +1498,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1681,6 +1720,45 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tower"
@@ -2110,6 +2188,12 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ tower-service = "0.3.3"
 metassr-create = { path = "crates/metassr-create" }
 metassr-bundler = { path = "crates/metassr-bundler" }
 metassr-fs-analyzer = { path = "crates/metassr-fs-analyzer" }
+metassr-config = { path = "crates/metassr-config" }
 metassr-watcher = { path = "crates/metassr-watcher" }
 regex = "1.12.3"
 dunce = "1.0.5"
@@ -57,6 +58,7 @@ members = [
   "crates/metassr-fs-analyzer",
   "crates/metassr-watcher",
   "crates/metassr-api-handler",
+  "crates/metassr-config",
 ]
 
 [workspace.package]

--- a/crates/metassr-config/Cargo.toml
+++ b/crates/metassr-config/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "metassr-config"
+version.workspace = true
+edition = "2021"
+
+[dependencies]
+toml = "1.1.3"

--- a/crates/metassr-config/Cargo.toml
+++ b/crates/metassr-config/Cargo.toml
@@ -5,3 +5,4 @@ edition = "2021"
 
 [dependencies]
 toml = "1.1.3"
+anyhow = "1.0.82"

--- a/crates/metassr-config/src/lib.rs
+++ b/crates/metassr-config/src/lib.rs
@@ -1,15 +1,16 @@
 pub struct MetaSSRConfig {
-    build: Option<toml::Value>,
-    server: Option<toml::Value>,
-    port: Option<toml::Value>,
+    build: Option<BuildConfig>,
+    server: Option<ServerConfig>,
 }
 
 impl MetaSSRConfig {
     fn new() -> Self {
         Self {
-            build: todo!(),
-            server: todo!(),
-            port: todo!(),
+            build: Some(BuildConfig {
+                _type: Some(String::from("SSSR")),
+                out_dir: Some(String::from("dist")),
+            }),
+            server: Some(ServerConfig { port: 8080 }),
         }
     }
 }
@@ -18,4 +19,13 @@ impl Default for MetaSSRConfig {
     fn default() -> Self {
         Self::new()
     }
+}
+
+struct BuildConfig {
+    _type: Option<String>,
+    out_dir: Option<String>,
+}
+
+struct ServerConfig {
+    port: u16,
 }

--- a/crates/metassr-config/src/lib.rs
+++ b/crates/metassr-config/src/lib.rs
@@ -1,17 +1,26 @@
+use std::path::Path;
+
 pub struct MetaSSRConfig {
-    build: Option<BuildConfig>,
-    server: Option<ServerConfig>,
+    _build: Option<BuildConfig>,
+    _server: Option<ServerConfig>,
 }
 
 impl MetaSSRConfig {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self {
-            build: Some(BuildConfig {
+            _build: Some(BuildConfig {
                 _type: Some(String::from("SSSR")),
-                out_dir: Some(String::from("dist")),
+                _out_dir: Some(String::from("dist")),
             }),
-            server: Some(ServerConfig { port: 8080 }),
+            _server: Some(ServerConfig { _port: 8080 }),
         }
+    }
+
+    pub fn load(_root: &Path) -> anyhow::Result<()> {
+        // find the config file and load it into memory
+        //
+        //validate syntax
+        Ok(())
     }
 }
 
@@ -23,9 +32,9 @@ impl Default for MetaSSRConfig {
 
 struct BuildConfig {
     _type: Option<String>,
-    out_dir: Option<String>,
+    _out_dir: Option<String>,
 }
 
 struct ServerConfig {
-    port: u16,
+    _port: u16,
 }

--- a/crates/metassr-config/src/lib.rs
+++ b/crates/metassr-config/src/lib.rs
@@ -1,0 +1,21 @@
+pub struct MetaSSRConfig {
+    build: Option<toml::Value>,
+    server: Option<toml::Value>,
+    port: Option<toml::Value>,
+}
+
+impl MetaSSRConfig {
+    fn new() -> Self {
+        Self {
+            build: todo!(),
+            server: todo!(),
+            port: todo!(),
+        }
+    }
+}
+
+impl Default for MetaSSRConfig {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/metassr-cli/Cargo.toml
+++ b/metassr-cli/Cargo.toml
@@ -24,6 +24,7 @@ metassr-bundler = { path = "../crates/metassr-bundler" }
 metassr-create = { path = "../crates/metassr-create" }
 metassr-watcher = { path = "../crates/metassr-watcher" }
 metassr-utils = { path = "../crates/metassr-utils" }
+metassr-config = { path = "../crates/metassr-config" }
 regex = "1.12.3"
 
 [build-dependencies]

--- a/metassr-cli/src/main.rs
+++ b/metassr-cli/src/main.rs
@@ -7,6 +7,7 @@ use cli::{
 use logger::LoggingLayer;
 
 use anyhow::Result;
+use metassr_config::MetaSSRConfig;
 
 use std::{
     env::{current_dir, set_current_dir, set_var},
@@ -53,6 +54,8 @@ async fn main() -> Result<()> {
             })
             .init();
         let project_root = Path::new(&args.root);
+
+        MetaSSRConfig::load(project_root)?;
 
         set_current_dir(project_root)
             .map_err(|err| eprintln!("Cannot chdir: {err}"))


### PR DESCRIPTION
As a step of #177 , this PR introduces the new crate `metassr-config` in the process of creating a TOML configuration for persistent config for MetaSSR devs and users.