### PR TITLE
Examples: init sales-dashboard example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,31 @@
+# Examples
+
+Example projects built with MetaSSR.
+
+## sales-dashboard
+
+A polyglot fullstack app demonstrating MetaSSR's API handler with Python and JavaScript backend routes and a React frontend.
+
+### Prerequisites
+
+- Rust toolchain (for building MetaSSR CLI)
+- Node.js + npm
+- Python 3
+
+### Start the example
+
+```sh
+cd examples/sales-dashboard
+npm install
+npm run dev
+```
+
+The dev server starts at `http://localhost:3000` and includes live reload.
+
+### What it demonstrates
+
+| Route | Language | Description |
+|---|---|---|
+| `GET/POST /api/sales` | **Python** | Hello-world API handler loaded via MetaCall's Python runtime |
+| `GET/POST /api/stats` | **JavaScript** | Hello-world API handler loaded via MetaCall's Node.js runtime |
+| `/` | React + TS | Frontend that fetches from both API routes and displays responses |

--- a/examples/sales-dashboard/metassr.toml
+++ b/examples/sales-dashboard/metassr.toml
@@ -1,0 +1,14 @@
+[build]
+type = "ssr"
+out_dir = "dist"
+
+[server]
+port = 8080
+
+[debug]
+mode = "off"
+
+[dev]
+hmr = true
+server_port = 3000
+ws_port = 3001

--- a/examples/sales-dashboard/package-lock.json
+++ b/examples/sales-dashboard/package-lock.json
@@ -1,107 +1,107 @@
 {
-    "name": "sales-dashboard",
-    "version": "1.0.0",
-    "lockfileVersion": 3,
-    "requires": true,
-    "packages": {
-        "": {
-            "name": "sales-dashboard",
-            "version": "1.0.0",
-            "dependencies": {
-                "react": "^18.3.1",
-                "react-dom": "^18.3.1"
-            },
-            "devDependencies": {
-                "@types/react": "^18.0.24",
-                "@types/react-dom": "^18.0.8"
-            }
-        },
-        "node_modules/@types/prop-types": {
-            "version": "15.7.15",
-            "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
-            "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@types/react": {
-            "version": "18.3.31",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
-            "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/prop-types": "*",
-                "csstype": "^3.2.2"
-            }
-        },
-        "node_modules/@types/react-dom": {
-            "version": "18.3.7",
-            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
-            "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-            "dev": true,
-            "license": "MIT",
-            "peerDependencies": {
-                "@types/react": "^18.0.0"
-            }
-        },
-        "node_modules/csstype": {
-            "version": "3.2.3",
-            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
-            "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/js-tokens": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-            "license": "MIT"
-        },
-        "node_modules/loose-envify": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-            "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-            "license": "MIT",
-            "dependencies": {
-                "js-tokens": "^3.0.0 || ^4.0.0"
-            },
-            "bin": {
-                "loose-envify": "cli.js"
-            }
-        },
-        "node_modules/react": {
-            "version": "18.3.1",
-            "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-            "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-            "license": "MIT",
-            "dependencies": {
-                "loose-envify": "^1.1.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/react-dom": {
-            "version": "18.3.1",
-            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-            "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-            "license": "MIT",
-            "dependencies": {
-                "loose-envify": "^1.1.0",
-                "scheduler": "^0.23.2"
-            },
-            "peerDependencies": {
-                "react": "^18.3.1"
-            }
-        },
-        "node_modules/scheduler": {
-            "version": "0.23.2",
-            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-            "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-            "license": "MIT",
-            "dependencies": {
-                "loose-envify": "^1.1.0"
-            }
-        }
+  "name": "sales-dashboard",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "sales-dashboard",
+      "version": "1.0.0",
+      "dependencies": {
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1"
+      },
+      "devDependencies": {
+        "@types/react": "^18.0.24",
+        "@types/react-dom": "^18.0.8"
+      }
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.31",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+      "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
     }
+  }
 }

--- a/examples/sales-dashboard/package-lock.json
+++ b/examples/sales-dashboard/package-lock.json
@@ -1,0 +1,107 @@
+{
+    "name": "sales-dashboard",
+    "version": "1.0.0",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "sales-dashboard",
+            "version": "1.0.0",
+            "dependencies": {
+                "react": "^18.3.1",
+                "react-dom": "^18.3.1"
+            },
+            "devDependencies": {
+                "@types/react": "^18.0.24",
+                "@types/react-dom": "^18.0.8"
+            }
+        },
+        "node_modules/@types/prop-types": {
+            "version": "15.7.15",
+            "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+            "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/react": {
+            "version": "18.3.31",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+            "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/prop-types": "*",
+                "csstype": "^3.2.2"
+            }
+        },
+        "node_modules/@types/react-dom": {
+            "version": "18.3.7",
+            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+            "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "@types/react": "^18.0.0"
+            }
+        },
+        "node_modules/csstype": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+            "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/js-tokens": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+            "license": "MIT"
+        },
+        "node_modules/loose-envify": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+            "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+            "license": "MIT",
+            "dependencies": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+            },
+            "bin": {
+                "loose-envify": "cli.js"
+            }
+        },
+        "node_modules/react": {
+            "version": "18.3.1",
+            "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+            "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+            "license": "MIT",
+            "dependencies": {
+                "loose-envify": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/react-dom": {
+            "version": "18.3.1",
+            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+            "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+            "license": "MIT",
+            "dependencies": {
+                "loose-envify": "^1.1.0",
+                "scheduler": "^0.23.2"
+            },
+            "peerDependencies": {
+                "react": "^18.3.1"
+            }
+        },
+        "node_modules/scheduler": {
+            "version": "0.23.2",
+            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+            "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+            "license": "MIT",
+            "dependencies": {
+                "loose-envify": "^1.1.0"
+            }
+        }
+    }
+}

--- a/examples/sales-dashboard/package.json
+++ b/examples/sales-dashboard/package.json
@@ -1,0 +1,21 @@
+{
+    "name": "sales-dashboard",
+    "version": "1.0.0",
+    "description": "MetaSSR polyglot example: Python + JavaScript API routes with React frontend",
+    "main": "src/pages/index.tsx",
+    "scripts": {
+        "metassr": "cargo run --bin metassr --",
+        "metassr:release": "cargo run --release --bin metassr --",
+        "build": "npm run metassr:release -- build",
+        "start": "npm run metassr:release -- start",
+        "dev": "npm run metassr -- dev"
+    },
+    "dependencies": {
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1"
+    },
+    "devDependencies": {
+        "@types/react": "^18.0.24",
+        "@types/react-dom": "^18.0.8"
+    }
+}

--- a/examples/sales-dashboard/package.json
+++ b/examples/sales-dashboard/package.json
@@ -1,21 +1,21 @@
 {
-    "name": "sales-dashboard",
-    "version": "1.0.0",
-    "description": "MetaSSR polyglot example: Python + JavaScript API routes with React frontend",
-    "main": "src/pages/index.tsx",
-    "scripts": {
-        "metassr": "cargo run --bin metassr --",
-        "metassr:release": "cargo run --release --bin metassr --",
-        "build": "npm run metassr:release -- build",
-        "start": "npm run metassr:release -- start",
-        "dev": "npm run metassr -- dev"
-    },
-    "dependencies": {
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1"
-    },
-    "devDependencies": {
-        "@types/react": "^18.0.24",
-        "@types/react-dom": "^18.0.8"
-    }
+  "name": "sales-dashboard",
+  "version": "1.0.0",
+  "description": "MetaSSR polyglot example: Python + JavaScript API routes with React frontend",
+  "main": "src/pages/index.tsx",
+  "scripts": {
+    "metassr": "cargo run --bin metassr --",
+    "metassr:release": "cargo run --release --bin metassr --",
+    "build": "npm run metassr:release -- build",
+    "start": "npm run metassr:release -- start",
+    "dev": "npm run metassr -- dev"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.24",
+    "@types/react-dom": "^18.0.8"
+  }
 }

--- a/examples/sales-dashboard/src/_app.tsx
+++ b/examples/sales-dashboard/src/_app.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import './styles/global.css';
 
-export default function App({ Component }) {
-    return <Component />;
+export default function App({ Component }: { Component: React.ComponentType }) {
+  return <Component />;
 }

--- a/examples/sales-dashboard/src/_app.tsx
+++ b/examples/sales-dashboard/src/_app.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import './styles/global.css';
+
+export default function App({ Component }) {
+    return <Component />;
+}

--- a/examples/sales-dashboard/src/_head.tsx
+++ b/examples/sales-dashboard/src/_head.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+export default function Head() {
+    return (
+        <>
+            <meta charSet="UTF-8" />
+            <meta name="viewport" content="width=device-width, initial-scale=1" />
+            <title>Sales Dashboard</title>
+        </>
+    );
+}

--- a/examples/sales-dashboard/src/api/sales.py
+++ b/examples/sales-dashboard/src/api/sales.py
@@ -1,27 +1,169 @@
 import json
-from datetime import datetime, timezone
+from datetime import datetime, timedelta
+
+import numpy as np
+import pandas as pd
+
+REGIONS = ["North", "South", "East", "West"]
+PRODUCTS = ["Widget", "Gadget", "Doohickey", "Contraption", "Thingamajig"]
+CATEGORIES = {
+    "Widget": "Electronics",
+    "Gadget": "Electronics",
+    "Doohickey": "Hardware",
+    "Contraption": "Hardware",
+    "Thingamajig": "Accessories",
+}
+
+
+def generate_sales_frame():
+    rng = np.random.default_rng(42)
+
+    start = datetime(2026, 1, 1)
+    end = datetime(2026, 12, 31)
+    date_pool = np.array(
+        [start + timedelta(days=i) for i in range((end - start).days + 1)],
+        dtype=object,
+    )
+
+    products = rng.choice(np.array(PRODUCTS, dtype=object), size=100)
+    regions = rng.choice(np.array(REGIONS, dtype=object), size=100)
+    units = rng.integers(1, 51, size=100)
+    prices = np.round(rng.uniform(10, 500, size=100), 2)
+    dates = rng.choice(date_pool, size=100)
+
+    frame = pd.DataFrame({
+        "date": pd.to_datetime(dates),
+        "region": regions,
+        "product": products,
+        "units": units.astype(int),
+        "price": prices.astype(float),
+    })
+    frame["category"] = frame["product"].map(CATEGORIES)
+    frame["revenue"] = (frame["units"] * frame["price"]).round(2)
+    return frame
+
+
+def compute_summary(frame):
+    if frame.empty:
+        return {
+            "totalRevenue": 0,
+            "avgOrder": 0,
+            "totalOrders": 0,
+            "totalUnits": 0,
+        }
+
+    revenue = frame["revenue"].to_numpy(dtype=float)
+    units = frame["units"].to_numpy(dtype=int)
+    return {
+        "totalRevenue": round(float(np.sum(revenue)), 2),
+        "avgOrder": round(float(np.mean(revenue)), 2),
+        "totalOrders": int(len(frame)),
+        "totalUnits": int(np.sum(units)),
+    }
+
+
+def build_charts(frame):
+    if frame.empty:
+        return {
+            "categoryRevenue": [],
+            "monthlyRevenue": [],
+            "regionRevenue": [],
+            "topProducts": [],
+        }
+
+    category_revenue = (
+        frame.groupby("category", as_index=False)["revenue"]
+        .sum()
+        .sort_values("category")
+    )
+    category_revenue["revenue"] = category_revenue["revenue"].round(2)
+
+    monthly = (
+        frame.assign(month=frame["date"].dt.to_period("M").astype(str))
+        .groupby("month", as_index=False)["revenue"]
+        .sum()
+        .sort_values("month")
+    )
+    monthly["revenue"] = monthly["revenue"].round(2)
+    monthly["growthPercent"] = (
+        monthly["revenue"]
+        .pct_change()
+        .replace([np.inf, -np.inf], 0)
+        .fillna(0)
+        .mul(100)
+        .round(2)
+    )
+    monthly["rollingAverage"] = monthly["revenue"].rolling(window=3, min_periods=1).mean().round(2)
+
+    region_revenue = (
+        frame.groupby("region", as_index=False)["revenue"]
+        .sum()
+        .sort_values("revenue", ascending=False)
+    )
+    region_revenue["revenue"] = region_revenue["revenue"].round(2)
+
+    top_products = (
+        frame.groupby(["product", "category"], as_index=False)
+        .agg(totalRevenue=("revenue", "sum"), totalUnits=("units", "sum"), orders=("product", "size"))
+        .sort_values("totalRevenue", ascending=False)
+    )
+    top_products["totalRevenue"] = top_products["totalRevenue"].round(2)
+    top_products["totalUnits"] = top_products["totalUnits"].astype(int)
+    top_products["orders"] = top_products["orders"].astype(int)
+
+    return {
+        "categoryRevenue": category_revenue.to_dict(orient="records"),
+        "monthlyRevenue": monthly.to_dict(orient="records"),
+        "regionRevenue": region_revenue.to_dict(orient="records"),
+        "topProducts": top_products.to_dict(orient="records"),
+    }
+
+
+def apply_filters(frame, body):
+    filtered = frame
+
+    region_filter = body.get("region")
+    if region_filter:
+        filtered = filtered[filtered["region"] == region_filter]
+
+    date_from = body.get("date_from")
+    if date_from:
+        filtered = filtered[filtered["date"] >= pd.to_datetime(date_from)]
+
+    date_to = body.get("date_to")
+    if date_to:
+        filtered = filtered[filtered["date"] <= pd.to_datetime(date_to)]
+
+    return filtered
+
+
+def build_payload(frame):
+    return {
+        "summary": compute_summary(frame),
+        "graphs": build_charts(frame),
+        "filters": {
+            "regions": REGIONS,
+            "products": PRODUCTS,
+        },
+    }
+
 
 def GET(_req):
+    frame = generate_sales_frame()
     return json.dumps({
         "status": 200,
-        "body": {
-            "message": "Hello from Python!",
-            "language": "Python",
-            "runtime": "MetaCall Python loader",
-            "timestamp": datetime.now(timezone.utc).isoformat()
-        }
+        "body": build_payload(frame),
     })
+
 
 def POST(req):
     req_obj = json.loads(req) if isinstance(req, str) else req
-    data = json.loads(req_obj.get("body", "{}")) if isinstance(req_obj.get("body"), str) else req_obj.get("body", {})
-    name = data.get("name", "anonymous")
+    body = json.loads(req_obj.get("body", "{}")) if isinstance(req_obj.get("body"), str) else req_obj.get("body", {})
+
+    frame = generate_sales_frame()
+    filtered = apply_filters(frame, body)
+
     return json.dumps({
-        "status": 201,
-        "body": {
-            "message": f"Hello, {name}!",
-            "language": "Python",
-            "received": data,
-            "timestamp": datetime.now(timezone.utc).isoformat()
-        }
+        "status": 200,
+        "body": build_payload(filtered),
     })

--- a/examples/sales-dashboard/src/api/sales.py
+++ b/examples/sales-dashboard/src/api/sales.py
@@ -1,0 +1,27 @@
+import json
+from datetime import datetime, timezone
+
+def GET(_req):
+    return json.dumps({
+        "status": 200,
+        "body": {
+            "message": "Hello from Python!",
+            "language": "Python",
+            "runtime": "MetaCall Python loader",
+            "timestamp": datetime.now(timezone.utc).isoformat()
+        }
+    })
+
+def POST(req):
+    req_obj = json.loads(req) if isinstance(req, str) else req
+    data = json.loads(req_obj.get("body", "{}")) if isinstance(req_obj.get("body"), str) else req_obj.get("body", {})
+    name = data.get("name", "anonymous")
+    return json.dumps({
+        "status": 201,
+        "body": {
+            "message": f"Hello, {name}!",
+            "language": "Python",
+            "received": data,
+            "timestamp": datetime.now(timezone.utc).isoformat()
+        }
+    })

--- a/examples/sales-dashboard/src/api/stats.js
+++ b/examples/sales-dashboard/src/api/stats.js
@@ -1,0 +1,28 @@
+function GET(_req) {
+    return JSON.stringify({
+        status: 200,
+        body: {
+            message: "Hello from JavaScript!",
+            language: "JavaScript",
+            runtime: "MetaCall Node.js loader",
+            timestamp: new Date().toISOString()
+        }
+    });
+}
+
+function POST(req) {
+    var reqObj = typeof req === 'string' ? JSON.parse(req) : req;
+    var data = reqObj.body ? JSON.parse(reqObj.body) : {};
+    name = data.name || "anonymous";
+    return JSON.stringify({
+        status: 201,
+        body: {
+            message: "Hello, " + name + "!",
+            language: "JavaScript",
+            received: data,
+            timestamp: new Date().toISOString()
+        }
+    });
+}
+
+module.exports = { GET: GET, POST: POST };

--- a/examples/sales-dashboard/src/api/stats.js
+++ b/examples/sales-dashboard/src/api/stats.js
@@ -1,28 +1,28 @@
 function GET(_req) {
-    return JSON.stringify({
-        status: 200,
-        body: {
-            message: "Hello from JavaScript!",
-            language: "JavaScript",
-            runtime: "MetaCall Node.js loader",
-            timestamp: new Date().toISOString()
-        }
-    });
+  return JSON.stringify({
+    status: 200,
+    body: {
+      message: "Hello from JavaScript!",
+      language: "JavaScript",
+      runtime: "MetaCall Node.js loader",
+      timestamp: new Date().toISOString()
+    }
+  });
 }
 
 function POST(req) {
-    var reqObj = typeof req === 'string' ? JSON.parse(req) : req;
-    var data = reqObj.body ? JSON.parse(reqObj.body) : {};
-    name = data.name || "anonymous";
-    return JSON.stringify({
-        status: 201,
-        body: {
-            message: "Hello, " + name + "!",
-            language: "JavaScript",
-            received: data,
-            timestamp: new Date().toISOString()
-        }
-    });
+  var reqObj = typeof req === 'string' ? JSON.parse(req) : req;
+  var data = reqObj.body ? JSON.parse(reqObj.body) : {};
+  name = data.name || "anonymous";
+  return JSON.stringify({
+    status: 201,
+    body: {
+      message: "Hello, " + name + "!",
+      language: "JavaScript",
+      received: data,
+      timestamp: new Date().toISOString()
+    }
+  });
 }
 
 module.exports = { GET: GET, POST: POST };

--- a/examples/sales-dashboard/src/pages/index.tsx
+++ b/examples/sales-dashboard/src/pages/index.tsx
@@ -1,91 +1,441 @@
 import React, { useEffect, useState } from 'react';
 
-type ApiResponse = {
-    message: string;
-    language: string;
-    runtime: string;
-    timestamp: string;
+type Summary = {
+  totalRevenue: number;
+  avgOrder: number;
+  totalOrders: number;
+  totalUnits: number;
 };
 
-export default function Index() {
-    const [pyResp, setPyResp] = useState<ApiResponse | null>(null);
-    const [jsResp, setJsResp] = useState<ApiResponse | null>(null);
-    const [error, setError] = useState('');
-    const [postName, setPostName] = useState('');
-    const [postLang, setPostLang] = useState<'python' | 'javascript'>('python');
-    const [postResp, setPostResp] = useState<string>('');
+type MonthlyPoint = {
+  month: string;
+  revenue: number;
+  growthPercent: number;
+  rollingAverage: number;
+};
 
-    useEffect(() => {
-        Promise.all([
-            fetch('/api/sales').then(r => r.json()),
-            fetch('/api/stats').then(r => r.json())
-        ])
-            .then(([py, js]) => {
-                setPyResp(py.body || py);
-                setJsResp(js.body || js);
-            })
-            .catch((err: Error) => setError(err.message));
-    }, []);
+type CategoryPoint = {
+  category: string;
+  revenue: number;
+};
 
-    const handlePost = (e: React.FormEvent) => {
-        e.preventDefault();
-        const endpoint = postLang === 'python' ? '/api/sales' : '/api/stats';
-        fetch(endpoint, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ name: postName || 'anonymous' })
-        })
-            .then(r => r.json())
-            .then(data => setPostResp(JSON.stringify(data.body || data, null, 2)))
-            .catch((err: Error) => setPostResp('Error: ' + err.message));
-    };
+type RegionPoint = {
+  region: string;
+  revenue: number;
+};
 
-    return (
-        <main className="page">
-            <h1>Sales Dashboard</h1>
-            <p className="subtitle">MetaSSR polyglot API demo</p>
+type ProductPoint = {
+  product: string;
+  category: string;
+  totalRevenue: number;
+  totalUnits: number;
+  orders: number;
+};
 
-            {error && <p className="error">{error}</p>}
+type SalesPayload = {
+  summary: Summary;
+  graphs: {
+    categoryRevenue: CategoryPoint[];
+    monthlyRevenue: MonthlyPoint[];
+    regionRevenue: RegionPoint[];
+    topProducts: ProductPoint[];
+  };
+  filters: {
+    regions: string[];
+    products: string[];
+  };
+};
 
-            <div className="cardGrid">
-                <section className="card">
-                    <h2>Python API <span className="badge">/api/sales</span></h2>
-                    {pyResp ? (
-                        <pre>{JSON.stringify(pyResp, null, 2)}</pre>
-                    ) : (
-                        <p className="loading">Loading&hellip;</p>
-                    )}
-                </section>
+type Filters = {
+  region: string;
+  dateFrom: string;
+  dateTo: string;
+};
 
-                <section className="card">
-                    <h2>JavaScript API <span className="badge">/api/stats</span></h2>
-                    {jsResp ? (
-                        <pre>{JSON.stringify(jsResp, null, 2)}</pre>
-                    ) : (
-                        <p className="loading">Loading&hellip;</p>
-                    )}
-                </section>
+const DEFAULT_REGIONS = ['North', 'South', 'East', 'West'];
+
+function formatCurrency(value: number) {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 0,
+  }).format(value);
+}
+
+function formatCompactCurrency(value: number) {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 1,
+    notation: 'compact',
+  }).format(value);
+}
+
+function formatMonthLabel(month: string) {
+  const [year, monthIndex] = month.split('-').map(Number);
+  if (!year || !monthIndex) {
+    return month;
+  }
+  return new Date(year, monthIndex - 1, 1).toLocaleString('en-US', { month: 'short' });
+}
+
+async function fetchSales(filters?: Filters): Promise<SalesPayload> {
+  const hasFilters = !!filters && (filters.region || filters.dateFrom || filters.dateTo);
+  const response = await fetch('/api/sales', {
+    method: hasFilters ? 'POST' : 'GET',
+    headers: hasFilters ? { 'Content-Type': 'application/json' } : undefined,
+    body: hasFilters
+      ? JSON.stringify({
+        region: filters?.region || undefined,
+        date_from: filters?.dateFrom || undefined,
+        date_to: filters?.dateTo || undefined,
+      })
+      : undefined,
+  });
+
+  const data = await response.json();
+  if (!response.ok || (typeof data.status === 'number' && data.status >= 400)) {
+    throw new Error(data?.error || 'Failed to load sales data');
+  }
+
+  return (data.body || data) as SalesPayload;
+}
+
+function MetricCard({ label, value, hint }: { label: string; value: string; hint: string }) {
+  return (
+    <article className="metricCard">
+      <p className="metricLabel">{label}</p>
+      <strong className="metricValue">{value}</strong>
+      <span className="metricHint">{hint}</span>
+    </article>
+  );
+}
+
+function HorizontalBarChart<T extends Record<string, string | number>>({
+  rows,
+  labelKey,
+  valueKey,
+  valueFormatter,
+}: {
+  rows: T[];
+  labelKey: keyof T;
+  valueKey: keyof T;
+  valueFormatter: (value: number) => string;
+}) {
+  const maxValue = Math.max(...rows.map(row => Number(row[valueKey])), 1);
+
+  return (
+    <div className="barChart">
+      {rows.map(row => {
+        const value = Number(row[valueKey]);
+        const label = String(row[labelKey]);
+        const width = `${Math.max((value / maxValue) * 100, 4)}%`;
+
+        return (
+          <div className="barRow" key={label}>
+            <div className="barRowTop">
+              <span className="barLabel">{label}</span>
+              <span className="barValue">{valueFormatter(value)}</span>
             </div>
+            <div className="barTrack">
+              <span className="barFill" style={{ width }} />
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
 
-            <section className="card postCard">
-                <h2>Try POST</h2>
-                <form onSubmit={handlePost}>
-                    <div className="formRow">
-                        <input
-                            type="text"
-                            placeholder="Your name"
-                            value={postName}
-                            onChange={e => setPostName(e.target.value)}
-                        />
-                        <select value={postLang} onChange={e => setPostLang(e.target.value as 'python' | 'javascript')}>
-                            <option value="python">/api/sales (Python)</option>
-                            <option value="javascript">/api/stats (JavaScript)</option>
-                        </select>
-                        <button type="submit">Send</button>
-                    </div>
-                </form>
-                {postResp && <pre className="postResult">{postResp}</pre>}
-            </section>
-        </main>
-    );
+function TrendChart({ rows }: { rows: MonthlyPoint[] }) {
+  const width = 760;
+  const height = 260;
+  const paddingX = 36;
+  const paddingY = 28;
+  const chartWidth = width - paddingX * 2;
+  const chartHeight = height - paddingY * 2;
+  const maxValue = Math.max(...rows.map(row => Math.max(row.revenue, row.rollingAverage)), 1);
+
+  const toPoint = (value: number, index: number) => {
+    const x = rows.length === 1 ? width / 2 : paddingX + (chartWidth * index) / (rows.length - 1);
+    const y = height - paddingY - (value / maxValue) * chartHeight;
+    return `${x},${y}`;
+  };
+
+  const revenuePoints = rows.map((row, index) => toPoint(row.revenue, index)).join(' ');
+  const averagePoints = rows.map((row, index) => toPoint(row.rollingAverage, index)).join(' ');
+
+  return (
+    <div className="trendChart">
+      <svg viewBox={`0 0 ${width} ${height}`} role="img" aria-label="Monthly revenue trend chart">
+        <defs>
+          <linearGradient id="trendFill" x1="0" x2="0" y1="0" y2="1">
+            <stop offset="0%" stopColor="rgba(6, 182, 212, 0.35)" />
+            <stop offset="100%" stopColor="rgba(6, 182, 212, 0)" />
+          </linearGradient>
+        </defs>
+        <line x1={paddingX} y1={height - paddingY} x2={width - paddingX} y2={height - paddingY} className="chartAxis" />
+        <polyline points={revenuePoints} className="trendLine" />
+        <polyline points={averagePoints} className="trendAverage" />
+        {rows.map((row, index) => {
+          const [x, y] = toPoint(row.revenue, index).split(',').map(Number);
+          return <circle key={row.month} cx={x} cy={y} r="4" className="trendDot" />;
+        })}
+      </svg>
+
+      <div className="trendLabels">
+        {rows.map(row => (
+          <div className="trendLabel" key={row.month}>
+            <span>{formatMonthLabel(row.month)}</span>
+            <strong>{formatCompactCurrency(row.revenue)}</strong>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function TopProductsTable({ rows }: { rows: ProductPoint[] }) {
+  return (
+    <div className="tableWrap">
+      <table className="dataTable">
+        <thead>
+          <tr>
+            <th>Product</th>
+            <th>Category</th>
+            <th>Revenue</th>
+            <th>Units</th>
+            <th>Orders</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map(row => (
+            <tr key={row.product}>
+              <td>{row.product}</td>
+              <td>{row.category}</td>
+              <td>{formatCurrency(row.totalRevenue)}</td>
+              <td>{row.totalUnits}</td>
+              <td>{row.orders}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export default function Index() {
+  const [payload, setPayload] = useState<SalesPayload | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [filters, setFilters] = useState<Filters>({
+    region: '',
+    dateFrom: '',
+    dateTo: '',
+  });
+
+  useEffect(() => {
+    let alive = true;
+
+    fetchSales()
+      .then(data => {
+        if (alive) {
+          setPayload(data);
+        }
+      })
+      .catch((err: Error) => {
+        if (alive) {
+          setError(err.message);
+        }
+      })
+      .finally(() => {
+        if (alive) {
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  const refresh = async (nextFilters?: Filters) => {
+    setLoading(true);
+    setError('');
+    try {
+      const data = await fetchSales(nextFilters);
+      setPayload(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load sales data');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    void refresh(filters);
+  };
+
+  const handleReset = () => {
+    const emptyFilters = { region: '', dateFrom: '', dateTo: '' };
+    setFilters(emptyFilters);
+    void refresh(emptyFilters);
+  };
+
+  const regionOptions = payload?.filters.regions || DEFAULT_REGIONS;
+  const summary = payload?.summary;
+  const graphs = payload?.graphs;
+
+  return (
+    <main className="page">
+      <section className="hero">
+        <div className="heroCopy">
+          <p className="eyebrow">NumPy + pandas dashboard</p>
+          <h1>Sales Dashboard</h1>
+          <p className="subtitle">
+            The Python API builds chart-ready aggregates from generated sales data.
+            The frontend fetches them and renders the graphs directly.
+          </p>
+        </div>
+
+        <form className="filtersPanel" onSubmit={handleSubmit}>
+          <div className="filtersGrid">
+            <label className="field">
+              <span>Region</span>
+              <select
+                value={filters.region}
+                onChange={e => setFilters(current => ({ ...current, region: e.target.value }))}
+              >
+                <option value="">All regions</option>
+                {regionOptions.map(region => (
+                  <option key={region} value={region}>{region}</option>
+                ))}
+              </select>
+            </label>
+
+            <label className="field">
+              <span>From</span>
+              <input
+                type="date"
+                value={filters.dateFrom}
+                onChange={e => setFilters(current => ({ ...current, dateFrom: e.target.value }))}
+              />
+            </label>
+
+            <label className="field">
+              <span>To</span>
+              <input
+                type="date"
+                value={filters.dateTo}
+                onChange={e => setFilters(current => ({ ...current, dateTo: e.target.value }))}
+              />
+            </label>
+          </div>
+
+          <div className="filtersActions">
+            <button type="submit">Update charts</button>
+            <button type="button" className="ghostButton" onClick={handleReset}>
+              Clear filters
+            </button>
+          </div>
+        </form>
+      </section>
+
+      {error && <p className="error">{error}</p>}
+
+      <section className="metricGrid">
+        <MetricCard
+          label="Total revenue"
+          value={summary ? formatCurrency(summary.totalRevenue) : 'Loading...'}
+          hint="All filtered orders"
+        />
+        <MetricCard
+          label="Average order"
+          value={summary ? formatCurrency(summary.avgOrder) : 'Loading...'}
+          hint="Mean revenue per order"
+        />
+        <MetricCard
+          label="Orders"
+          value={summary ? summary.totalOrders.toString() : 'Loading...'}
+          hint="Generated rows in the dataset"
+        />
+        <MetricCard
+          label="Units sold"
+          value={summary ? summary.totalUnits.toString() : 'Loading...'}
+          hint="Total item count"
+        />
+      </section>
+
+      <section className="chartGrid">
+        <article className="card chartCard wide">
+          <div className="cardHeader">
+            <div>
+              <h2>Monthly revenue trend</h2>
+              <p>Revenue line plus a 3-month rolling average.</p>
+            </div>
+          </div>
+          {loading && !graphs ? (
+            <p className="loading">Loading chart data...</p>
+          ) : graphs?.monthlyRevenue?.length ? (
+            <TrendChart rows={graphs.monthlyRevenue} />
+          ) : (
+            <p className="loading">No data for the selected filters.</p>
+          )}
+        </article>
+
+        <article className="card chartCard">
+          <div className="cardHeader">
+            <div>
+              <h2>Revenue by category</h2>
+              <p>Grouped from the pandas DataFrame.</p>
+            </div>
+          </div>
+          {graphs?.categoryRevenue?.length ? (
+            <HorizontalBarChart
+              rows={graphs.categoryRevenue}
+              labelKey="category"
+              valueKey="revenue"
+              valueFormatter={formatCurrency}
+            />
+          ) : (
+            <p className="loading">No data available.</p>
+          )}
+        </article>
+
+        <article className="card chartCard">
+          <div className="cardHeader">
+            <div>
+              <h2>Revenue by region</h2>
+              <p>Use the filter form to narrow the chart.</p>
+            </div>
+          </div>
+          {graphs?.regionRevenue?.length ? (
+            <HorizontalBarChart
+              rows={graphs.regionRevenue}
+              labelKey="region"
+              valueKey="revenue"
+              valueFormatter={formatCurrency}
+            />
+          ) : (
+            <p className="loading">No data available.</p>
+          )}
+        </article>
+      </section>
+
+      <section className="card chartCard tableCard">
+        <div className="cardHeader">
+          <div>
+            <h2>Top products</h2>
+            <p>Sorted by total revenue with pandas groupby aggregations.</p>
+          </div>
+        </div>
+        {graphs?.topProducts?.length ? (
+          <TopProductsTable rows={graphs.topProducts} />
+        ) : (
+          <p className="loading">No data available.</p>
+        )}
+      </section>
+    </main>
+  );
 }

--- a/examples/sales-dashboard/src/pages/index.tsx
+++ b/examples/sales-dashboard/src/pages/index.tsx
@@ -1,0 +1,91 @@
+import React, { useEffect, useState } from 'react';
+
+type ApiResponse = {
+    message: string;
+    language: string;
+    runtime: string;
+    timestamp: string;
+};
+
+export default function Index() {
+    const [pyResp, setPyResp] = useState<ApiResponse | null>(null);
+    const [jsResp, setJsResp] = useState<ApiResponse | null>(null);
+    const [error, setError] = useState('');
+    const [postName, setPostName] = useState('');
+    const [postLang, setPostLang] = useState<'python' | 'javascript'>('python');
+    const [postResp, setPostResp] = useState<string>('');
+
+    useEffect(() => {
+        Promise.all([
+            fetch('/api/sales').then(r => r.json()),
+            fetch('/api/stats').then(r => r.json())
+        ])
+            .then(([py, js]) => {
+                setPyResp(py.body || py);
+                setJsResp(js.body || js);
+            })
+            .catch((err: Error) => setError(err.message));
+    }, []);
+
+    const handlePost = (e: React.FormEvent) => {
+        e.preventDefault();
+        const endpoint = postLang === 'python' ? '/api/sales' : '/api/stats';
+        fetch(endpoint, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ name: postName || 'anonymous' })
+        })
+            .then(r => r.json())
+            .then(data => setPostResp(JSON.stringify(data.body || data, null, 2)))
+            .catch((err: Error) => setPostResp('Error: ' + err.message));
+    };
+
+    return (
+        <main className="page">
+            <h1>Sales Dashboard</h1>
+            <p className="subtitle">MetaSSR polyglot API demo</p>
+
+            {error && <p className="error">{error}</p>}
+
+            <div className="cardGrid">
+                <section className="card">
+                    <h2>Python API <span className="badge">/api/sales</span></h2>
+                    {pyResp ? (
+                        <pre>{JSON.stringify(pyResp, null, 2)}</pre>
+                    ) : (
+                        <p className="loading">Loading&hellip;</p>
+                    )}
+                </section>
+
+                <section className="card">
+                    <h2>JavaScript API <span className="badge">/api/stats</span></h2>
+                    {jsResp ? (
+                        <pre>{JSON.stringify(jsResp, null, 2)}</pre>
+                    ) : (
+                        <p className="loading">Loading&hellip;</p>
+                    )}
+                </section>
+            </div>
+
+            <section className="card postCard">
+                <h2>Try POST</h2>
+                <form onSubmit={handlePost}>
+                    <div className="formRow">
+                        <input
+                            type="text"
+                            placeholder="Your name"
+                            value={postName}
+                            onChange={e => setPostName(e.target.value)}
+                        />
+                        <select value={postLang} onChange={e => setPostLang(e.target.value as 'python' | 'javascript')}>
+                            <option value="python">/api/sales (Python)</option>
+                            <option value="javascript">/api/stats (JavaScript)</option>
+                        </select>
+                        <button type="submit">Send</button>
+                    </div>
+                </form>
+                {postResp && <pre className="postResult">{postResp}</pre>}
+            </section>
+        </main>
+    );
+}

--- a/examples/sales-dashboard/src/styles/global.css
+++ b/examples/sales-dashboard/src/styles/global.css
@@ -1,0 +1,111 @@
+*, *::before, *::after { box-sizing: border-box; }
+
+body {
+    margin: 0;
+    min-height: 100vh;
+    background: #f4f1ea;
+    color: #1f2933;
+    font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+h1, h2, p { margin-top: 0; }
+h1 { margin-bottom: 4px; font-size: clamp(1.8rem, 5vw, 2.8rem); }
+h2 { margin-bottom: 12px; font-size: 1rem; color: #52616b; text-transform: uppercase; letter-spacing: 0.5px; }
+
+.page {
+    width: min(900px, calc(100% - 32px));
+    margin: 0 auto;
+    padding: 48px 0;
+}
+
+.subtitle {
+    margin-bottom: 28px;
+    color: #52616b;
+    font-size: 0.95rem;
+}
+
+.error {
+    padding: 14px 16px;
+    border: 1px solid #ffb4a2;
+    border-radius: 8px;
+    background: #fff1ed;
+    color: #9f1239;
+    margin-bottom: 16px;
+}
+
+.loading { color: #52616b; }
+
+.cardGrid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 16px;
+    margin-bottom: 16px;
+}
+
+@media (max-width: 640px) { .cardGrid { grid-template-columns: 1fr; } }
+
+.card {
+    padding: 20px;
+    border: 1px solid #d1d7dc;
+    border-radius: 8px;
+    background: #fff;
+}
+
+.postCard { grid-column: 1 / -1; }
+
+.badge {
+    display: inline-block;
+    padding: 1px 8px;
+    border-radius: 4px;
+    background: #e4e7eb;
+    font-size: 0.78rem;
+    font-weight: 400;
+    color: #52616b;
+    text-transform: none;
+    letter-spacing: 0;
+}
+
+pre {
+    margin: 0;
+    padding: 12px;
+    border-radius: 6px;
+    background: #faf9f6;
+    font-size: 0.85rem;
+    overflow-x: auto;
+    white-space: pre-wrap;
+    word-break: break-all;
+}
+
+.formRow {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+}
+
+.formRow input, .formRow select {
+    padding: 8px 12px;
+    border: 1px solid #b8c0c8;
+    border-radius: 8px;
+    background: #fff;
+    font: inherit;
+    font-size: 0.9rem;
+    color: #1f2933;
+    flex: 1;
+    min-width: 140px;
+}
+
+button {
+    border: 0;
+    border-radius: 999px;
+    background: #006d77;
+    padding: 9px 18px;
+    color: #fff;
+    cursor: pointer;
+    font: inherit;
+    font-size: 0.85rem;
+    font-weight: 700;
+    white-space: nowrap;
+}
+button:hover { opacity: 0.9; }
+
+.postResult { margin-top: 12px; }

--- a/examples/sales-dashboard/src/styles/global.css
+++ b/examples/sales-dashboard/src/styles/global.css
@@ -1,4 +1,6 @@
-*, *::before, *::after { box-sizing: border-box; }
+*, *::before, *::after {
+    box-sizing: border-box;
+}
 
 body {
     margin: 0;
@@ -8,104 +10,350 @@ body {
     font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
 
-h1, h2, p { margin-top: 0; }
-h1 { margin-bottom: 4px; font-size: clamp(1.8rem, 5vw, 2.8rem); }
-h2 { margin-bottom: 12px; font-size: 1rem; color: #52616b; text-transform: uppercase; letter-spacing: 0.5px; }
+code {
+    border-radius: 4px;
+    background: #e4e7eb;
+    padding: 2px 5px;
+    font-size: 0.95em;
+}
+
+h1,
+h2,
+p {
+    margin-top: 0;
+}
+
+h1 {
+    margin-bottom: 12px;
+    font-size: clamp(2rem, 7vw, 4rem);
+    line-height: 1;
+}
+
+h2 {
+    margin-bottom: 8px;
+    font-size: 1rem;
+}
 
 .page {
-    width: min(900px, calc(100% - 32px));
+    width: min(1180px, calc(100% - 32px));
     margin: 0 auto;
     padding: 48px 0;
 }
 
-.subtitle {
-    margin-bottom: 28px;
-    color: #52616b;
-    font-size: 0.95rem;
-}
-
-.error {
-    padding: 14px 16px;
-    border: 1px solid #ffb4a2;
-    border-radius: 8px;
-    background: #fff1ed;
-    color: #9f1239;
-    margin-bottom: 16px;
-}
-
-.loading { color: #52616b; }
-
-.cardGrid {
+.hero {
     display: grid;
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: minmax(0, 1.1fr) minmax(320px, 0.9fr);
     gap: 16px;
     margin-bottom: 16px;
 }
 
-@media (max-width: 640px) { .cardGrid { grid-template-columns: 1fr; } }
+.heroCopy {
+    max-width: 760px;
+}
 
-.card {
-    padding: 20px;
+.eyebrow {
+    margin: 0 0 10px;
+    color: #006d77;
+    font-size: 0.8rem;
+    font-weight: 700;
+    letter-spacing: 0;
+    text-transform: uppercase;
+}
+
+.subtitle {
+    margin-bottom: 0;
+    color: #52616b;
+    font-size: 1.05rem;
+    line-height: 1.7;
+}
+
+.filtersPanel,
+.card,
+.metricCard {
     border: 1px solid #d1d7dc;
     border-radius: 8px;
-    background: #fff;
+    background: #ffffff;
 }
 
-.postCard { grid-column: 1 / -1; }
+.filtersPanel {
+    padding: 20px;
+}
 
-.badge {
-    display: inline-block;
-    padding: 1px 8px;
-    border-radius: 4px;
-    background: #e4e7eb;
-    font-size: 0.78rem;
-    font-weight: 400;
+.filtersGrid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 12px;
+}
+
+.field {
+    display: grid;
+    gap: 6px;
     color: #52616b;
-    text-transform: none;
-    letter-spacing: 0;
+    font-size: 0.78rem;
+    font-weight: 700;
+    text-transform: uppercase;
 }
 
-pre {
-    margin: 0;
-    padding: 12px;
-    border-radius: 6px;
-    background: #faf9f6;
-    font-size: 0.85rem;
-    overflow-x: auto;
-    white-space: pre-wrap;
-    word-break: break-all;
-}
-
-.formRow {
-    display: flex;
-    gap: 8px;
-    flex-wrap: wrap;
-}
-
-.formRow input, .formRow select {
-    padding: 8px 12px;
+.field input,
+.field select {
+    width: 100%;
     border: 1px solid #b8c0c8;
     border-radius: 8px;
-    background: #fff;
-    font: inherit;
-    font-size: 0.9rem;
+    background: #ffffff;
+    padding: 9px 10px;
     color: #1f2933;
-    flex: 1;
-    min-width: 140px;
+    font: inherit;
+    font-size: 0.95rem;
+    text-transform: none;
+}
+
+.filtersActions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-top: 14px;
 }
 
 button {
     border: 0;
     border-radius: 999px;
     background: #006d77;
-    padding: 9px 18px;
-    color: #fff;
+    padding: 9px 14px;
+    color: #ffffff;
     cursor: pointer;
     font: inherit;
     font-size: 0.85rem;
     font-weight: 700;
-    white-space: nowrap;
 }
-button:hover { opacity: 0.9; }
 
-.postResult { margin-top: 12px; }
+button:disabled {
+    cursor: not-allowed;
+    opacity: 0.55;
+}
+
+.ghostButton,
+.secondaryButton {
+    border: 1px solid #b8c0c8;
+    background: #ffffff;
+    color: #1f2933;
+}
+
+.error {
+    margin-bottom: 16px;
+    border: 1px solid #ffb4a2;
+    border-radius: 8px;
+    background: #fff1ed;
+    padding: 14px 16px;
+    color: #9f1239;
+}
+
+.metricGrid {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 16px;
+    margin-bottom: 16px;
+}
+
+.metricCard {
+    display: grid;
+    gap: 8px;
+    padding: 18px;
+}
+
+.metricLabel {
+    margin-bottom: 0;
+    color: #52616b;
+    font-size: 0.78rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.metricValue {
+    font-size: 1.7rem;
+    color: #1f2933;
+}
+
+.metricHint {
+    color: #52616b;
+    font-size: 0.88rem;
+}
+
+.chartGrid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 16px;
+    margin-bottom: 16px;
+}
+
+.card {
+    padding: 20px;
+}
+
+.chartCard.wide {
+    grid-column: 1 / -1;
+}
+
+.cardHeader {
+    margin-bottom: 16px;
+}
+
+.cardHeader p {
+    margin-bottom: 0;
+    color: #52616b;
+}
+
+.loading {
+    margin-bottom: 0;
+    color: #52616b;
+}
+
+.barChart {
+    display: grid;
+    gap: 14px;
+}
+
+.barRow {
+    display: grid;
+    gap: 8px;
+}
+
+.barRowTop {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 16px;
+}
+
+.barLabel,
+.barValue {
+    font-size: 0.92rem;
+}
+
+.barValue {
+    color: #52616b;
+}
+
+.barTrack {
+    position: relative;
+    height: 12px;
+    overflow: hidden;
+    border-radius: 999px;
+    background: #e4e7eb;
+}
+
+.barFill {
+    position: absolute;
+    inset: 0 auto 0 0;
+    display: block;
+    border-radius: inherit;
+    background: #006d77;
+}
+
+.trendChart {
+    display: grid;
+    gap: 12px;
+}
+
+.trendChart svg {
+    width: 100%;
+    height: auto;
+    overflow: visible;
+}
+
+.chartAxis {
+    stroke: #d1d7dc;
+    stroke-width: 1.5;
+}
+
+.trendLine {
+    fill: none;
+    stroke: #006d77;
+    stroke-width: 3.5;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+}
+
+.trendAverage {
+    fill: none;
+    stroke: #7b8794;
+    stroke-width: 2.5;
+    stroke-dasharray: 8 7;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+}
+
+.trendDot {
+    fill: #ffffff;
+    stroke: #006d77;
+    stroke-width: 2;
+}
+
+.trendLabels {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(92px, 1fr));
+    gap: 10px;
+}
+
+.trendLabel {
+    display: grid;
+    gap: 4px;
+    border-radius: 8px;
+    background: #faf9f6;
+    padding: 12px;
+}
+
+.trendLabel span {
+    color: #52616b;
+    font-size: 0.78rem;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+}
+
+.trendLabel strong {
+    color: #1f2933;
+    font-size: 0.95rem;
+}
+
+.tableWrap {
+    overflow: auto;
+}
+
+.dataTable {
+    width: 100%;
+    min-width: 620px;
+    border-collapse: collapse;
+}
+
+.dataTable th,
+.dataTable td {
+    padding: 12px 10px;
+    border-bottom: 1px solid #d1d7dc;
+    text-align: left;
+}
+
+.dataTable th {
+    color: #52616b;
+    font-size: 0.78rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.dataTable tbody tr:hover {
+    background: #faf9f6;
+}
+
+@media (max-width: 960px) {
+    .hero,
+    .metricGrid,
+    .chartGrid,
+    .filtersGrid {
+        grid-template-columns: 1fr;
+    }
+
+    .chartCard.wide {
+        grid-column: auto;
+    }
+}

--- a/examples/sales-dashboard/tsconfig.json
+++ b/examples/sales-dashboard/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "jsx": "react",
+    "target": "es2016",
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
+  }
+}

--- a/examples/sales-dashboard/tsconfig.json
+++ b/examples/sales-dashboard/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "jsx": "react",
-    "target": "es2016",
+    "target": "es2018",
     "module": "commonjs",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
## Changes

- Add `/examples` directory
- Add an initial `sales-dashboard` example. Using Python and JavaScript in the API routes side, to help visualizing data by Python (numpy/pandas) and doing regular web dev stuff (auth/db calls/stats computation) by JavaScript. 

## Why `/examples`, not inside `/tests`?

The examples directory should be for full web apps as an example for devs and users/AI to clone and take inspiration of. While tests should remain to evaluate specific features and be used in integration tests.