### PR TITLE
feat(bench-ci): persist benchmark results and compare against latest master

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -2,15 +2,12 @@ name: Bench
 
 on:
   push:
-    branches: ["master"]
+    branches-ignore: ["benchmark-data"]
   pull_request:
-    branches: ["master"]
-  pull_request_target:
-    branches: ["master"]
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   actions: write
 
 concurrency:
@@ -64,44 +61,6 @@ jobs:
           npm install
           npm run build
 
-      # --- Baseline run (pull_request_target only) ---
-      - name: Checkout base ref
-        if: github.event_name == 'pull_request_target'
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.base.sha }}
-          path: base
-
-      - name: Build baseline metassr
-        if: github.event_name == 'pull_request_target'
-        run: cargo build --release
-        working-directory: ./base
-        env:
-          CARGO_TARGET_DIR: ${{ github.workspace }}/target
-
-      - name: Run baseline benchmarks
-        if: github.event_name == 'pull_request_target'
-        run: |
-          cp ${{ github.workspace }}/target/release/metassr /tmp/metassr-baseline
-          PATH="/tmp:$PATH" metassr-baseline start --port 8080 &
-          for i in $(seq 1 30); do
-            curl --silent --output /dev/null http://localhost:8080 2>/dev/null && break
-            sleep 1
-          done
-          python3 head/benchmarks/benchmark.py --skip-build --output ${{ github.workspace }}/.bench/baseline --port 8080
-          kill $(lsof -ti:8080) 2>/dev/null || true
-          sleep 2
-
-      # --- Current run (always) ---
-      - name: Build metassr (current)
-        run: cargo build --release
-        working-directory: ./head
-        env:
-          CARGO_TARGET_DIR: ${{ github.workspace }}/target
-
-      - name: Install binary (current)
-        run: sudo cp ${{ github.workspace }}/target/release/metassr /usr/local/bin/metassr
-
       - name: Start server
         working-directory: ./head/benchmarks/apps/metassr-app
         run: |
@@ -117,17 +76,68 @@ jobs:
       - name: Stop server
         run: kill $(lsof -ti:8080) 2>/dev/null || true
 
-      # --- Comparison ---
-      - name: Generate comparison report
-        if: github.event_name == 'pull_request_target'
-        run: python3 head/benchmarks/benchmark.py --compare ${{ github.workspace }}/.bench/baseline/results.json ${{ github.workspace }}/.bench/current/results.json --output ${{ github.workspace }}/.bench/
-
-      - name: Copy current summary for push events
-        if: github.event_name != 'pull_request_target'
-        run: cp ${{ github.workspace }}/.bench/current/summary.md ${{ github.workspace }}/.bench/summary.md
-
       - name: Post summary to job page
-        run: cat ${{ github.workspace }}/.bench/summary.md >> $GITHUB_STEP_SUMMARY
+        run: cat ${{ github.workspace }}/.bench/current/summary.md >> $GITHUB_STEP_SUMMARY
+
+      - name: Resolve branch and SHA
+        id: refs
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "branch=${{ github.head_ref }}" >> "$GITHUB_OUTPUT"
+            echo "sha=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "branch=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+            echo "sha=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Fetch benchmark data branch
+        run: bash head/scripts/benchmark-results.sh fetch /tmp/bench-data
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Compare with latest master
+        run: |
+          if [ -f "/tmp/bench-data/results/master/latest.json" ]; then
+            if python3 head/benchmarks/benchmark.py \
+              --compare /tmp/bench-data/results/master/latest.json \
+              ${{ github.workspace }}/.bench/current/results.json \
+              --output ${{ github.workspace }}/.bench/compare-master \
+              --base-label "Master" \
+              --current-label "${{ steps.refs.outputs.branch }}"; then
+              echo "### Benchmark vs latest master commit" >> $GITHUB_STEP_SUMMARY
+              cat ${{ github.workspace }}/.bench/compare-master/summary.md >> $GITHUB_STEP_SUMMARY
+            else
+              echo "Comparison against latest master failed"
+            fi
+          else
+            echo "No benchmark for latest master commit yet"
+          fi
+
+      - name: Compare with previous branch commit
+        if: github.event_name == 'push'
+        run: |
+          branch="${{ steps.refs.outputs.branch }}"
+          if [ "$branch" != "master" ] && [ "$branch" != "main" ] && [ -f "/tmp/bench-data/results/$branch/latest.json" ]; then
+            if python3 head/benchmarks/benchmark.py \
+              --compare "/tmp/bench-data/results/$branch/latest.json" \
+              ${{ github.workspace }}/.bench/current/results.json \
+              --output ${{ github.workspace }}/.bench/compare-branch \
+              --base-label "Previous" \
+              --current-label "$branch"; then
+              echo "### Benchmark vs previous commit on branch" >> $GITHUB_STEP_SUMMARY
+              cat ${{ github.workspace }}/.bench/compare-branch/summary.md >> $GITHUB_STEP_SUMMARY
+            else
+              echo "Comparison against previous branch commit failed"
+            fi
+          else
+            echo "No previous benchmark for branch $branch"
+          fi
+
+      - name: Store benchmark results
+        if: github.event_name == 'push'
+        run: bash head/scripts/benchmark-results.sh store /tmp/bench-data ${{ steps.refs.outputs.sha }} ${{ steps.refs.outputs.branch }} ${{ github.workspace }}/.bench/current/results.json
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Upload results
         if: always()

--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -340,7 +340,7 @@ xychart-beta
     
     return summary
 
-def generate_comparison(baseline_file, current_file, output_dir):
+def generate_comparison(baseline_file, current_file, output_dir, base_label="Baseline", current_label="Current"):
     """Generate comparison summary between two benchmark runs."""
     baseline = json.loads(Path(baseline_file).read_text())
     current = json.loads(Path(current_file).read_text())
@@ -396,7 +396,7 @@ def generate_comparison(baseline_file, current_file, output_dir):
         return f"{ms:.2f}ms"
 
     table_rows = []
-    for name, _ in SCENARIOS:
+    for name, *_ in SCENARIOS:
         b = base_index[name]
         c = curr_index[name]
         rps_d = delta_str(b["rps"], c["rps"])
@@ -423,7 +423,7 @@ def generate_comparison(baseline_file, current_file, output_dir):
 
 ## Performance Charts
 
-Legend: bars in order — **Baseline**, **Current**
+Legend: bars in order — **{base_label}**, **{current_label}**
 
 ### Requests per Second
 ```mermaid
@@ -477,13 +477,13 @@ xychart-beta
 
 ## Detailed Comparison
 
-| Test | Base RPS | PR RPS | RPS Δ | Base Latency | PR Latency | Lat Δ | Base P99 | PR P99 | P99 Δ | Base Mem | PR Mem | Mem Δ |
+| Test | {base_label} RPS | {current_label} RPS | RPS Δ | {base_label} Latency | {current_label} Latency | Lat Δ | {base_label} P99 | {current_label} P99 | P99 Δ | {base_label} Mem | {current_label} Mem | Mem Δ |
 |------|----------|--------|-------|-------------|-----------|-------|---------|-------|-------|----------|--------|-------|
 {chr(10).join(table_rows)}
 
 ## Summary
 
-| Metric | Baseline | Current | Delta |
+| Metric | {base_label} | {current_label} | Delta |
 |--------|----------|---------|-------|
 | Avg RPS | {avg_base_rps:,.0f} | {avg_curr_rps:,.0f} | {delta_str(avg_base_rps, avg_curr_rps)} |
 | Avg Latency | {fmt_lat(avg_base_lat)} | {fmt_lat(avg_curr_lat)} | {delta_str(avg_base_lat, avg_curr_lat)} |
@@ -530,6 +530,10 @@ def main():
     parser.add_argument("--analyze-only", metavar="FILE", help="Only analyze existing results.json")
     parser.add_argument("--compare", nargs=2, metavar=("BASELINE", "CURRENT"),
                         help="Compare two results.json files and generate comparison summary")
+    parser.add_argument("--base-label", default="Baseline",
+                        help="Label for the baseline in the comparison report (default: Baseline)")
+    parser.add_argument("--current-label", default="Current",
+                        help="Label for the current run in the comparison report (default: Current)")
     args = parser.parse_args()
     
     # Handle compare mode
@@ -539,7 +543,8 @@ def main():
             if not Path(f).exists():
                 error(f"File not found: {f}")
                 sys.exit(1)
-        generate_comparison(baseline_file, current_file, args.output)
+        generate_comparison(baseline_file, current_file, args.output,
+                            args.base_label, args.current_label)
         return
     
     # Handle analyze-only mode

--- a/scripts/benchmark-results.sh
+++ b/scripts/benchmark-results.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+#
+# Manage the persistent benchmark results stored on the `benchmark-data` branch.
+#
+# Usage:
+#   benchmark-results.sh fetch <dir>
+#   benchmark-results.sh store <dir> <sha> <branch> <results.json>
+#
+# fetch clones (or bootstraps) the `benchmark-data` branch into <dir>.
+# store writes <sha>.json and latest.json under results/<branch>/ and pushes
+# the update back to the `benchmark-data` branch.
+#
+# Requires GITHUB_REPOSITORY, GITHUB_TOKEN and GITHUB_ACTOR to be set.
+
+set -euo pipefail
+
+DATA_BRANCH="benchmark-data"
+REMOTE_URL="${BENCHMARK_REMOTE_URL:-https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git}"
+
+fetch_branch() {
+    local dir="$1"
+
+    if [ ! -d "$dir/.git" ]; then
+        rm -rf "$dir"
+        mkdir -p "$dir"
+        git init -q "$dir"
+        git -C "$dir" remote add origin "$REMOTE_URL"
+    fi
+
+    git -C "$dir" fetch -q origin "$DATA_BRANCH" 2>/dev/null || true
+
+    if git -C "$dir" rev-parse --verify "refs/remotes/origin/$DATA_BRANCH" >/dev/null 2>&1; then
+        git -C "$dir" checkout -q -B "$DATA_BRANCH" "origin/$DATA_BRANCH"
+    else
+        git -C "$dir" checkout -q --orphan "$DATA_BRANCH"
+        git -C "$dir" rm -rf -q --ignore-unmatch .
+    fi
+
+    echo "fetched $DATA_BRANCH into $dir"
+}
+
+store_results() {
+    local dir="$1"
+    local sha="$2"
+    local branch="$3"
+    local results_file="$4"
+    local results_dir
+
+    if [ ! -f "$results_file" ]; then
+        echo "error: results file not found: $results_file" >&2
+        exit 1
+    fi
+
+    results_dir="$dir/results/$branch"
+    mkdir -p "$results_dir"
+    cp "$results_file" "$results_dir/$sha.json"
+    cp "$results_file" "$results_dir/latest.json"
+
+    git -C "$dir" config user.name "${GITHUB_ACTOR:-github-actions[bot]}"
+    git -C "$dir" config user.email "${GITHUB_ACTOR:-github-actions[bot]}@users.noreply.github.com"
+
+    git -C "$dir" add -A
+    if git -C "$dir" diff --cached --quiet; then
+        echo "no changes to commit"
+        return 0
+    fi
+
+    git -C "$dir" commit -q -m "benchmark results for $sha ($branch)"
+    git -C "$dir" push -q origin "$DATA_BRANCH:$DATA_BRANCH"
+
+    echo "stored benchmark results for $sha ($branch) on $DATA_BRANCH"
+}
+
+main() {
+    if [ $# -lt 1 ]; then
+        echo "usage: benchmark-results.sh {fetch <dir> | store <dir> <sha> <branch> <results.json>}" >&2
+        exit 1
+    fi
+
+    if [ -z "${GITHUB_REPOSITORY:-}" ] || [ -z "${GITHUB_TOKEN:-}" ]; then
+        echo "error: GITHUB_REPOSITORY and GITHUB_TOKEN must be set" >&2
+        exit 1
+    fi
+
+    local cmd="$1"
+    shift
+
+    case "$cmd" in
+        fetch)
+            if [ $# -ne 1 ]; then
+                echo "usage: benchmark-results.sh fetch <dir>" >&2
+                exit 1
+            fi
+            fetch_branch "$1"
+            ;;
+        store)
+            if [ $# -ne 4 ]; then
+                echo "usage: benchmark-results.sh store <dir> <sha> <branch> <results.json>" >&2
+                exit 1
+            fi
+            store_results "$@"
+            ;;
+        *)
+            echo "error: unknown command: $cmd" >&2
+            exit 1
+            ;;
+    esac
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Makes every benchmark run produce a comparison against:
1. the **latest `origin/master` commit** benchmark result, and
2. the **previous commit on the current branch** (when the branch isn't `master`/`main` and a previous result exists).

Instead of publishing a static site, benchmark results are stored on a lightweight `benchmark-data` branch in this repo using `GITHUB_TOKEN` (no PAT / Pages / admin needed).

## Changes

- **`.github/workflows/bench.yml`**
  - Triggers on `push` to any branch (excluding `benchmark-data`) + `pull_request` + `workflow_dispatch`
  - Drops the unused `pull_request_target` trigger and its baseline build/compare flow
  - After benchmarking: fetches the data branch, compares vs latest master and vs the previous branch commit (posted to the job summary), and stores results on push events
  - `permissions: contents: write` so the runner can push the data branch
- **`scripts/benchmark-results.sh`** (new)
  - `fetch <dir>` / `store <dir> <sha> <branch> <results.json>`: clones/bootstraps the `benchmark-data` branch (self-healing on first run) and commits+pulls back via `GITHUB_TOKEN`
- **`benchmarks/benchmark.py`**
  - `--compare` gains `--base-label` / `--current-label` (defaults `Baseline`/`Current`) for readable master/branch comparison headers
  - Fixes a pre-existing bug: `for name, _ in SCENARIOS` unpacked 4-tuples and crashed any `--compare` run

## Layout on `benchmark-data`

```
results/
  master/           <- latest origin/master result (results/master/latest.json)
  <branch>/<sha>.json, <branch>/latest.json
```

## Notes
- First-ever master run has no baseline yet — comparison is skipped gracefully and seeds `results/master/latest.json`.
- Fork PRs benchmark and compare vs master but do not store (read-only token).
- Pushing to `benchmark-data` does not re-trigger the workflow (`branches-ignore`).