### PR TITLE
chore: inherit workspace version in metassr-api-handler

### DIFF
--- a/crates/metassr-api-handler/Cargo.toml
+++ b/crates/metassr-api-handler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metassr-api-handler"
-version = "1.0.0-alpha"
+version.workspace = true
 edition = "2021"
 description = "API routes handler for MetaSSR with polyglot support"
 


### PR DESCRIPTION
## What

`crates/metassr-api-handler/Cargo.toml` hardcoded `version = "1.0.0-alpha"` while every other workspace member inherits from `[workspace.package]` via `version.workspace = true`.

This normalizes it to `version.workspace = true`, matching the rest of the workspace.

## Why

The hardcoded value happened to match the workspace version today, but it would silently drift on the next version bump. This was introduced with the crate in #140, after the workspace-version migration.

## Verification

- `cargo metadata` resolves `metassr-api-handler` to `1.0.0-alpha` (the workspace version).
- No functional change; single-line manifest edit.