### PR TITLE
feat(docker): add MetaSSR base image

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,7 @@
+# Docker
+
+Dockerfiles for MetaSSR containers.
+
+- [`base.Dockerfile`](./base.Dockerfile) — the MetaSSR base image: MetaCall + Node/npm + the `metassr` CLI.
+
+See the [containers guide](../docs/getting-started/docker.md) for what these images are and how to use them.

--- a/docker/base.Dockerfile
+++ b/docker/base.Dockerfile
@@ -1,0 +1,54 @@
+# MetaSSR base image: the `metassr` CLI + MetaCall runtime + Node/npm.
+#
+# Built for linux/amd64. Multi-arch (linux/arm64) is tracked in #193.
+#
+# NOTE: the `builder` stage compiles `metassr` from source so the image is
+# self-contained. Once `metassr` binaries are published via GitHub Releases,
+# replace that stage with a download/copy of the prebuilt binary (tracked in #193).
+
+ARG METACALL_VERSION=0.9.23
+
+# MetaCall runtime, also the source of /usr/local for the builder.
+FROM metacall/core:${METACALL_VERSION}-runtime AS metacall
+
+# Build stage
+FROM rust:slim-trixie AS builder
+
+RUN apt-get update \
+	&& DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+		ca-certificates \
+		git \
+		wget \
+		pkg-config \
+		cmake \
+		gcc \
+		libclang-dev \
+	&& rm -rf /var/lib/apt/lists/*
+
+COPY --from=metacall /usr/local /usr/local
+
+WORKDIR /src
+COPY . .
+RUN cargo build --release --locked
+
+# Runtime stage
+FROM metacall/core:${METACALL_VERSION}-runtime AS runtime
+
+ARG METACALL_VERSION=0.9.23
+ARG METASSR_VERSION=1.0.0-alpha
+
+RUN apt-get update \
+	&& DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+		npm \
+	&& rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /src/target/release/metassr /usr/local/bin/metassr
+
+LABEL org.opencontainers.image.title="MetaSSR" \
+	org.opencontainers.image.description="MetaSSR base image: CLI + MetaCall runtime + Node/npm" \
+	org.opencontainers.image.source="https://github.com/metacall/metassr" \
+	org.metacall.metassr.version="${METASSR_VERSION}" \
+	org.metacall.metacall.version="${METACALL_VERSION}"
+
+WORKDIR /app
+ENTRYPOINT ["metassr"]

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ Welcome to the official documentation for MetaSSR Framework. This guide will hel
 If you're new to the SSR Framework, start here! The [Getting Started](./getting-started) section provides everything you need to set up your environment, understand the prerequisites, and start building your first application.
 
 - [Installation](./getting-started/installation.md)
+- [Containers](./getting-started/docker.md)
 - [Command line interface](./getting-started/cli.md)
 - [Folder Structure](./getting-started/folder-structure.md)
 

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -5,6 +5,7 @@ Welcome to the MetaSSR Getting Started guide! This folder provides essential inf
 
 - [Overview](#overview)
 - [Installation Guide](#installation-guide)
+- [Containers](#containers)
 - [Folder Structure](#folder-structure)
 - [Command-Line Interface (CLI) Documentation](#command-line-interface-cli-documentation)
 - [Getting Help](#getting-help)
@@ -23,6 +24,12 @@ To get MetaSSR up and running on your system, follow the detailed installation i
 - Building and installing MetaSSR from source
 
 You can find the installation guide [here](installation.md).
+
+## Containers
+
+If you would rather not install MetaCall, Node and the CLI by hand, you can use the MetaSSR base image, which already has them. The `docker.md` file explains what the base image is and how to build an app image from it.
+
+You can read the containers guide [here](docker.md).
 
 ## Folder Structure
 

--- a/docs/getting-started/docker.md
+++ b/docs/getting-started/docker.md
@@ -1,0 +1,95 @@
+# Containers
+
+MetaSSR can run in a container, so you don't have to install MetaCall, Node and the CLI by hand on every machine.
+
+> **Status:** the base image is available now for linux/amd64. The app image pattern below is upcoming.
+
+## The images
+
+There are two kinds of images:
+
+- **Base image** — a MetaSSR installation, packaged. MetaCall, Node + npm, and the `metassr` CLI. No app, no source.
+- **App image** — your built app on top of the base image. *(upcoming)*
+
+People building MetaSSR itself use `Dockerfile.dev` instead.
+
+## What the base image is
+
+Think of it as a machine that already has MetaSSR installed:
+
+| | |
+| --- | --- |
+| Base OS | Debian 13 (trixie) |
+| MetaCall | 0.9.23 |
+| Node / npm | v20 / 9.x |
+| MetaSSR CLI | `metassr` on `PATH` |
+| Working dir | `/app` |
+| Entrypoint | `metassr` |
+
+It is the same set of dependencies the [installation guide](./installation.md) asks you to install by hand, just baked into an image.
+
+It is **not**:
+
+- an installer — it doesn't put `metassr` on your host;
+- an app image — it has no `dist/`, `src/api` or `metassr.toml`;
+- an image for building MetaSSR itself (that's `Dockerfile.dev`).
+
+## Using the base image
+
+Run the CLI:
+
+```sh
+docker run --rm metacall/metassr:1.0.0-alpha --version
+```
+
+Build an app without installing anything on your host:
+
+```sh
+docker run --rm -v "$PWD":/app -w /app --entrypoint sh \
+  metacall/metassr:1.0.0-alpha \
+  -c "npm install && metassr build -t ssr"
+```
+
+The entrypoint is `metassr`, so use `--entrypoint sh` when you want a shell.
+
+## Building an app image (upcoming)
+
+An app image is a two-stage build: build the app with the base image, then copy the result into a fresh base image.
+
+```dockerfile
+FROM metacall/metassr:1.0.0-alpha AS build
+WORKDIR /app
+COPY . .
+RUN npm install && metassr build -t ssr
+
+FROM metacall/metassr:1.0.0-alpha AS runtime
+WORKDIR /app
+COPY --from=build /app/dist ./dist
+COPY --from=build /app/src/api ./src/api
+COPY --from=build /app/metassr.toml .
+EXPOSE 8080
+CMD ["start"]
+```
+
+Two things to remember:
+
+- `metassr start` scans `src/api` to register API routes, so the runtime image needs that folder too.
+- Python API routes bring their own packages (for example `numpy` or `pandas`). The base image keeps Python bare on purpose — install what your app needs in its own image.
+
+## Building the base image
+
+The base image is built locally; nothing is pushed to a registry:
+
+```sh
+docker build --platform linux/amd64 -f docker/base.Dockerfile -t metacall/metassr:1.0.0-alpha .
+```
+
+## CI
+
+Use the base image as the job environment so CI matches local development.
+
+## Notes
+
+- **Architecture:** linux/amd64 only for now; linux/arm64 is tracked in [#193](https://github.com/metacall/metassr/issues/193).
+- **Size:** large (~2.8 GB) because it bundles the MetaCall runtime.
+- **Temporary:** the image currently compiles `metassr` from source in a builder stage. Once release binaries exist it will just download one ([#193](https://github.com/metacall/metassr/issues/193)).

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -14,6 +14,7 @@ Welcome to _**MetaSSR**_! This guide will walk you through the installation proc
     - [2. Compiling](#2-compiling)
     - [3. Add the CLI Binary to PATH (Linux)](#3-add-the-cli-binary-to-path-linux)
     - [4. Create Your First Project](#4-create-your-first-project)
+  - [Containers](#containers)
   - [Conclusion](#conclusion)
 
 ## Manual Installation Steps from Source
@@ -65,6 +66,10 @@ After completing the above steps, you'll be able to create your first web applic
 ```bash
 $ metassr create <project-name>
 ```
+
+## Containers
+
+Instead of installing MetaCall, Node and the CLI by hand, you can use the MetaSSR base image, which already has them. It is the same installation, packaged. See the [containers guide](./docker.md) for the base image and the app image pattern.
 
 ## Deployment
 


### PR DESCRIPTION
Adds `docker/base.Dockerfile`, a linux/amd64 base image with the `metassr` CLI + MetaCall 0.9.23 + Node/npm.

- builder: `rust:slim-trixie` + MetaCall libs → `cargo build --release --locked`
- runtime: `metacall/core:0.9.23-runtime` + npm + `metassr` binary

Verified: `metassr --version`; built and served `tests/web-app` (HTTP 200, JS + Python API routes).

Docs: `docs/getting-started/docker.md` explains what the base image is, how to use it, and the (upcoming) app image pattern.

Multi-arch and swapping the builder for a prebuilt binary are tracked in #193.